### PR TITLE
Added a GetRow function, and modified hrpc.Get to hold families.

### DIFF
--- a/client.go
+++ b/client.go
@@ -32,7 +32,9 @@ var (
 		StopKey:    []byte{},
 	}
 
-	infoFamily = []byte("info")
+	infoFamily = map[string][]string{
+		"info": nil,
+	}
 )
 
 // region -> client cache.
@@ -111,7 +113,16 @@ func NewClient(zkquorum string) *Client {
 
 // CheckTable returns an error if the given table name doesn't exist.
 func (c *Client) CheckTable(table string) (*pb.GetResponse, error) {
-	resp, err := c.sendRpcToRegion(hrpc.NewGetStr(table, "theKey"))
+	resp, err := c.sendRpcToRegion(hrpc.NewGetStr(table, "theKey", nil))
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*pb.GetResponse), err
+}
+
+// GetRow returns a single row fetched from hbase
+func (c *Client) GetRow(table string, rowkey string, families map[string][]string) (*pb.GetResponse, error) {
+	resp, err := c.sendRpcToRegion(hrpc.NewGetStr(table, rowkey, families))
 	if err != nil {
 		return nil, err
 	}

--- a/hrpc/get.go
+++ b/hrpc/get.go
@@ -57,7 +57,7 @@ func (g *Get) Serialize() ([]byte, error) {
 		},
 	}
 	for family, qualifiers := range g.families {
-		bytequals := make([][]byte, len(qualifiers), len(qualifiers))
+		bytequals := make([][]byte, len(qualifiers))
 		for i, qual := range qualifiers {
 			bytequals[i] = []byte(qual)
 		}

--- a/hrpc/get.go
+++ b/hrpc/get.go
@@ -14,31 +14,31 @@ import (
 type Get struct {
 	base
 
-	family []byte
+	families map[string][]string //Maps a column family to a list of qualifiers
 
 	closestBefore bool
 }
 
 // NewGetStr creates a new Get request for the given table/key.
-func NewGetStr(table, key string) *Get {
+func NewGetStr(table, key string, families map[string][]string) *Get {
 	return &Get{
 		base: base{
 			table: []byte(table),
 			key:   []byte(key),
 		},
-		// TODO
+		families: families,
 	}
 }
 
 // NewGetBefore creates a new Get request for the row right before the given
 // key in the given table and family.
-func NewGetBefore(table, key, family []byte) *Get {
+func NewGetBefore(table, key []byte, families map[string][]string) *Get {
 	return &Get{
 		base: base{
 			table: table,
 			key:   key,
 		},
-		family:        family,
+		families:      families,
 		closestBefore: true,
 	}
 }
@@ -56,13 +56,16 @@ func (g *Get) Serialize() ([]byte, error) {
 			Row: g.key,
 		},
 	}
-	if g.family != nil {
-		get.Get.Column = []*pb.Column{
-			&pb.Column{
-				Family: g.family,
-				//Qualifier: [][]byte{[]byte("theCol")},
-			},
+	for family, qualifiers := range g.families {
+		bytequals := make([][]byte, len(qualifiers), len(qualifiers))
+		for i, qual := range qualifiers {
+			bytequals[i] = []byte(qual)
 		}
+		get.Get.Column = append(get.Get.Column,
+			&pb.Column{
+				Family:    []byte(family),
+				Qualifier: bytequals,
+			})
 	}
 	if g.closestBefore {
 		get.Get.ClosestRowBefore = proto.Bool(true)


### PR DESCRIPTION
I've added the function GetRow to client.go, which will return a row given a table, key, and a set of families and qualifiers.

I also modified hrpc.Get to store a mapping of families to lists of qualifiers, which is used when serializing the request.