### PR TITLE
Multithread writes

### DIFF
--- a/client.go
+++ b/client.go
@@ -129,15 +129,15 @@ func (c *Client) Get(table string, rowkey string, families map[string][]string) 
 	return resp.(*pb.GetResponse), err
 }
 
-/*
-func (c *Client) NewScan(table string, families map[string][]string, startRow, stopRow *[]byte) ([]*pb.ScanResponse, error) {
+// Scan will retrieve the values specified in families from multiple rows in
+// the given hbase table.
+func (c *Client) Scan(table string, families map[string][]string, startRow, stopRow []byte) (*pb.ScanResponse, error) {
 	resp, err := c.sendRpcToRegion(hrpc.NewScanStr(table, families, startRow, stopRow))
 	if err != nil {
 		return nil, err
 	}
 	return resp.(*pb.ScanResponse), err
 }
-*/
 
 // Put will insert or update the values into the given row the table and rowkey
 // correspond to

--- a/client.go
+++ b/client.go
@@ -32,7 +32,9 @@ var (
 		StopKey:    []byte{},
 	}
 
-	infoFamily = []byte("info")
+	infoFamily = map[string][]string{
+		"info": nil,
+	}
 )
 
 // region -> client cache.
@@ -111,7 +113,16 @@ func NewClient(zkquorum string) *Client {
 
 // CheckTable returns an error if the given table name doesn't exist.
 func (c *Client) CheckTable(table string) (*pb.GetResponse, error) {
-	resp, err := c.sendRpcToRegion(hrpc.NewGetStr(table, "theKey"))
+	resp, err := c.sendRpcToRegion(hrpc.NewGetStr(table, "theKey", nil))
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*pb.GetResponse), err
+}
+
+// GetRow returns a single row fetched from hbase
+func (c *Client) GetRow(table string, rowkey string, families map[string][]string) (*pb.GetResponse, error) {
+	resp, err := c.sendRpcToRegion(hrpc.NewGetStr(table, rowkey, families))
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -129,7 +129,7 @@ func (c *Client) Get(table string, rowkey string, families map[string][]string) 
 	return resp.(*pb.GetResponse), err
 }
 
-// Scan will retrieve the values specified in families from multiple rows in
+// Scan retrieves the values specified in families from multiple rows in
 // the given hbase table.
 func (c *Client) Scan(table string, families map[string][]string, startRow, stopRow []byte) (*pb.ScanResponse, error) {
 	resp, err := c.sendRpcToRegion(hrpc.NewScanStr(table, families, startRow, stopRow))
@@ -139,7 +139,7 @@ func (c *Client) Scan(table string, families map[string][]string, startRow, stop
 	return resp.(*pb.ScanResponse), err
 }
 
-// Put will insert or update the values into the given row the table and rowkey
+// Put inserts or updates the values into the given row the table and rowkey
 // correspond to
 func (c *Client) Put(table string, rowkey string, values map[string]map[string][]byte) (*pb.MutateResponse, error) {
 	resp, err := c.sendRpcToRegion(hrpc.NewPutStr(table, rowkey, values))
@@ -158,7 +158,7 @@ func (c *Client) Delete(table, rowkey string, values map[string]map[string][]byt
 	return resp.(*pb.MutateResponse), err
 }
 
-// Append will append all given values to their current values in the given row
+// Append appends all given values to their current values in the given row
 // corresponding to the given table and rowkey
 func (c *Client) Append(table, rowkey string, values map[string]map[string][]byte) (*pb.MutateResponse, error) {
 	resp, err := c.sendRpcToRegion(hrpc.NewAppStr(table, rowkey, values))
@@ -168,7 +168,7 @@ func (c *Client) Append(table, rowkey string, values map[string]map[string][]byt
 	return resp.(*pb.MutateResponse), err
 }
 
-// Increment will add the given values to their corresponding values in hbase
+// Increment adds the given values to their corresponding values in hbase
 func (c *Client) Increment(table, rowkey string, values map[string]map[string][]byte) (*pb.MutateResponse, error) {
 	resp, err := c.sendRpcToRegion(hrpc.NewIncStr(table, rowkey, values))
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -120,13 +120,61 @@ func (c *Client) CheckTable(table string) (*pb.GetResponse, error) {
 	return resp.(*pb.GetResponse), err
 }
 
-// GetRow returns a single row fetched from hbase
-func (c *Client) GetRow(table string, rowkey string, families map[string][]string) (*pb.GetResponse, error) {
+// Get fetches a single row from hbase
+func (c *Client) Get(table string, rowkey string, families map[string][]string) (*pb.GetResponse, error) {
 	resp, err := c.sendRpcToRegion(hrpc.NewGetStr(table, rowkey, families))
 	if err != nil {
 		return nil, err
 	}
 	return resp.(*pb.GetResponse), err
+}
+
+/*
+func (c *Client) NewScan(table string, families map[string][]string, startRow, stopRow *[]byte) ([]*pb.ScanResponse, error) {
+	resp, err := c.sendRpcToRegion(hrpc.NewScanStr(table, families, startRow, stopRow))
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*pb.ScanResponse), err
+}
+*/
+
+// Put will insert or update the values into the given row the table and rowkey
+// correspond to
+func (c *Client) Put(table string, rowkey string, values map[string]map[string][]byte) (*pb.MutateResponse, error) {
+	resp, err := c.sendRpcToRegion(hrpc.NewPutStr(table, rowkey, values))
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*pb.MutateResponse), err
+}
+
+// Delete removes values from thw given row the table and rowkey correspond to
+func (c *Client) Delete(table, rowkey string, values map[string]map[string][]byte) (*pb.MutateResponse, error) {
+	resp, err := c.sendRpcToRegion(hrpc.NewDelStr(table, rowkey, values))
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*pb.MutateResponse), err
+}
+
+// Append will append all given values to their current values in the given row
+// corresponding to the given table and rowkey
+func (c *Client) Append(table, rowkey string, values map[string]map[string][]byte) (*pb.MutateResponse, error) {
+	resp, err := c.sendRpcToRegion(hrpc.NewAppStr(table, rowkey, values))
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*pb.MutateResponse), err
+}
+
+// Increment will add the given values to their corresponding values in hbase
+func (c *Client) Increment(table, rowkey string, values map[string]map[string][]byte) (*pb.MutateResponse, error) {
+	resp, err := c.sendRpcToRegion(hrpc.NewIncStr(table, rowkey, values))
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*pb.MutateResponse), err
 }
 
 // Creates the META key to search for in order to locate the given key.

--- a/hrpc/get.go
+++ b/hrpc/get.go
@@ -57,7 +57,7 @@ func (g *Get) Serialize() ([]byte, error) {
 		},
 	}
 	for family, qualifiers := range g.families {
-		bytequals := make([][]byte, len(qualifiers), len(qualifiers))
+		bytequals := make([][]byte, len(qualifiers))
 		for i, qual := range qualifiers {
 			bytequals[i] = []byte(qual)
 		}

--- a/hrpc/get.go
+++ b/hrpc/get.go
@@ -14,31 +14,31 @@ import (
 type Get struct {
 	base
 
-	family []byte
+	families map[string][]string //Maps a column family to a list of qualifiers
 
 	closestBefore bool
 }
 
 // NewGetStr creates a new Get request for the given table/key.
-func NewGetStr(table, key string) *Get {
+func NewGetStr(table, key string, families map[string][]string) *Get {
 	return &Get{
 		base: base{
 			table: []byte(table),
 			key:   []byte(key),
 		},
-		// TODO
+		families: families,
 	}
 }
 
 // NewGetBefore creates a new Get request for the row right before the given
 // key in the given table and family.
-func NewGetBefore(table, key, family []byte) *Get {
+func NewGetBefore(table, key []byte, families map[string][]string) *Get {
 	return &Get{
 		base: base{
 			table: table,
 			key:   key,
 		},
-		family:        family,
+		families:      families,
 		closestBefore: true,
 	}
 }
@@ -56,13 +56,16 @@ func (g *Get) Serialize() ([]byte, error) {
 			Row: g.key,
 		},
 	}
-	if g.family != nil {
-		get.Get.Column = []*pb.Column{
-			&pb.Column{
-				Family: g.family,
-				//Qualifier: [][]byte{[]byte("theCol")},
-			},
+	for family, qualifiers := range g.families {
+		bytequals := make([][]byte, len(qualifiers), len(qualifiers))
+		for i, qual := range qualifiers {
+			bytequals[i] = []byte(qual)
 		}
+		get.Get.Column = append(get.Get.Column,
+			&pb.Column{
+				Family:    []byte(family),
+				Qualifier: bytequals,
+			})
 	}
 	if g.closestBefore {
 		get.Get.ClosestRowBefore = proto.Bool(true)

--- a/hrpc/mutate.go
+++ b/hrpc/mutate.go
@@ -1,0 +1,125 @@
+// Copyright (C) 2015  The GoHBase Authors.  All rights reserved.
+// This file is part of GoHBase.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+package hrpc
+
+import (
+	"github.com/golang/protobuf/proto"
+	"github.com/tsuna/gohbase/pb"
+)
+
+// Get represents a Mutation HBase call.
+type Mutate struct {
+	base
+
+	row          *[]byte
+	mutationType pb.MutationProto_MutationType //*int32
+
+	//values is a map of column families to a map of column qualifiers to bytes
+	values map[string]map[string][]byte
+}
+
+// NewPutStr creates a new Mutation request that will put the given values into
+// HBase under the given table and key.
+func NewPutStr(table, key string, values map[string]map[string][]byte) *Mutate {
+	return &Mutate{
+		base: base{
+			table: []byte(table),
+			key:   []byte(key),
+		},
+		mutationType: pb.MutationProto_PUT,
+		values:       values,
+	}
+}
+
+// NewPutStr creates a new Mutation request that will delete the given values
+// from HBase under the given table and key.
+func NewDelStr(table, key string, values map[string]map[string][]byte) *Mutate {
+	return &Mutate{
+		base: base{
+			table: []byte(table),
+			key:   []byte(key),
+		},
+		mutationType: pb.MutationProto_DELETE,
+		values:       values,
+	}
+}
+
+// NewAppStr creates a new Mutation request that will append the given values
+// to their existing values in HBase under the given table and key.
+func NewAppStr(table, key string, values map[string]map[string][]byte) *Mutate {
+	return &Mutate{
+		base: base{
+			table: []byte(table),
+			key:   []byte(key),
+		},
+		mutationType: pb.MutationProto_APPEND,
+		values:       values,
+	}
+}
+
+// NewIncStr creates a new Mutation request that will increment the given values
+// in HBase under the given table and key.
+func NewIncStr(table, key string, values map[string]map[string][]byte) *Mutate {
+	return &Mutate{
+		base: base{
+			table: []byte(table),
+			key:   []byte(key),
+		},
+		mutationType: pb.MutationProto_INCREMENT,
+		values:       values,
+	}
+}
+
+// Name returns the name of this RPC call.
+func (m *Mutate) Name() string {
+	return "Mutate"
+}
+
+// Serialize converts this mutate object into a protobuf message suitable for
+// sending to an hbase server
+func (m *Mutate) Serialize() ([]byte, error) {
+	// We need to convert everything in the values field
+	// to a protobuf ColumnValue
+	bytevalues := make([]*pb.MutationProto_ColumnValue, len(m.values))
+	counter := 0
+	for k, v := range m.values {
+		qualvals := make([]*pb.MutationProto_ColumnValue_QualifierValue, len(v))
+		counter1 := 0
+		// And likewise, each item in each column needs to be converted to a
+		// protobuf QualifierValue
+		for k1, v1 := range v {
+			qualvals[counter1] = &pb.MutationProto_ColumnValue_QualifierValue{
+				Qualifier: []byte(k1),
+				Value:     v1,
+			}
+			if m.mutationType == pb.MutationProto_DELETE {
+				tmp := pb.MutationProto_DELETE_MULTIPLE_VERSIONS
+				qualvals[counter1].DeleteType = &tmp
+			}
+			counter1++
+		}
+		bytevalues[counter] = &pb.MutationProto_ColumnValue{
+			Family:         []byte(k),
+			QualifierValue: qualvals,
+		}
+		counter++
+	}
+	mutate := &pb.MutateRequest{
+		Region: m.regionSpecifier(),
+		Mutation: &pb.MutationProto{
+			Row:         m.key,
+			MutateType:  &m.mutationType,
+			ColumnValue: bytevalues,
+		},
+	}
+	return proto.Marshal(mutate)
+}
+
+// NewResponse creates an empty protobuf message to read the response of this
+// RPC.
+func (m *Mutate) NewResponse() proto.Message {
+	return &pb.MutateResponse{}
+}

--- a/hrpc/mutate.go
+++ b/hrpc/mutate.go
@@ -75,28 +75,28 @@ func (m *Mutate) Serialize() ([]byte, error) {
 	// We need to convert everything in the values field
 	// to a protobuf ColumnValue
 	bytevalues := make([]*pb.MutationProto_ColumnValue, len(m.values))
-	counter := 0
+	i := 0
 	for k, v := range m.values {
 		qualvals := make([]*pb.MutationProto_ColumnValue_QualifierValue, len(v))
-		counter1 := 0
+		j := 0
 		// And likewise, each item in each column needs to be converted to a
 		// protobuf QualifierValue
 		for k1, v1 := range v {
-			qualvals[counter1] = &pb.MutationProto_ColumnValue_QualifierValue{
+			qualvals[j] = &pb.MutationProto_ColumnValue_QualifierValue{
 				Qualifier: []byte(k1),
 				Value:     v1,
 			}
 			if m.mutationType == pb.MutationProto_DELETE {
 				tmp := pb.MutationProto_DELETE_MULTIPLE_VERSIONS
-				qualvals[counter1].DeleteType = &tmp
+				qualvals[j].DeleteType = &tmp
 			}
-			counter1++
+			j++
 		}
-		bytevalues[counter] = &pb.MutationProto_ColumnValue{
+		bytevalues[i] = &pb.MutationProto_ColumnValue{
 			Family:         []byte(k),
 			QualifierValue: qualvals,
 		}
-		counter++
+		i++
 	}
 	mutate := &pb.MutateRequest{
 		Region: m.regionSpecifier(),

--- a/hrpc/mutate.go
+++ b/hrpc/mutate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tsuna/gohbase/pb"
 )
 
-// Get represents a Mutation HBase call.
+// Mutate represents the Mutate HBase RPC call
 type Mutate struct {
 	base
 
@@ -21,56 +21,47 @@ type Mutate struct {
 	values map[string]map[string][]byte
 }
 
-// NewPutStr creates a new Mutation request that will put the given values into
-// HBase under the given table and key.
-func NewPutStr(table, key string, values map[string]map[string][]byte) *Mutate {
+// baseMutate will return a Mutate struct without the mutationType filled in.
+func baseMutate(table, key string, values map[string]map[string][]byte) *Mutate {
 	return &Mutate{
 		base: base{
 			table: []byte(table),
 			key:   []byte(key),
 		},
-		mutationType: pb.MutationProto_PUT,
-		values:       values,
+		values: values,
 	}
+}
+
+// NewPutStr creates a new Mutation request that will put the given values into
+// HBase under the given table and key.
+func NewPutStr(table, key string, values map[string]map[string][]byte) *Mutate {
+	m := baseMutate(table, key, values)
+	m.mutationType = pb.MutationProto_PUT
+	return m
 }
 
 // NewPutStr creates a new Mutation request that will delete the given values
 // from HBase under the given table and key.
 func NewDelStr(table, key string, values map[string]map[string][]byte) *Mutate {
-	return &Mutate{
-		base: base{
-			table: []byte(table),
-			key:   []byte(key),
-		},
-		mutationType: pb.MutationProto_DELETE,
-		values:       values,
-	}
+	m := baseMutate(table, key, values)
+	m.mutationType = pb.MutationProto_DELETE
+	return m
 }
 
 // NewAppStr creates a new Mutation request that will append the given values
 // to their existing values in HBase under the given table and key.
 func NewAppStr(table, key string, values map[string]map[string][]byte) *Mutate {
-	return &Mutate{
-		base: base{
-			table: []byte(table),
-			key:   []byte(key),
-		},
-		mutationType: pb.MutationProto_APPEND,
-		values:       values,
-	}
+	m := baseMutate(table, key, values)
+	m.mutationType = pb.MutationProto_APPEND
+	return m
 }
 
 // NewIncStr creates a new Mutation request that will increment the given values
 // in HBase under the given table and key.
 func NewIncStr(table, key string, values map[string]map[string][]byte) *Mutate {
-	return &Mutate{
-		base: base{
-			table: []byte(table),
-			key:   []byte(key),
-		},
-		mutationType: pb.MutationProto_INCREMENT,
-		values:       values,
-	}
+	m := baseMutate(table, key, values)
+	m.mutationType = pb.MutationProto_INCREMENT
+	return m
 }
 
 // Name returns the name of this RPC call.

--- a/hrpc/scan.go
+++ b/hrpc/scan.go
@@ -5,7 +5,6 @@
 
 package hrpc
 
-/*
 import (
 	"github.com/golang/protobuf/proto"
 	"github.com/tsuna/gohbase/pb"
@@ -30,22 +29,23 @@ type Scan struct {
 // column families and qualifiers will be returned. When run, a scanner Id will
 // also be returned, that can be used to fetch addition results via successive
 // Scan requests.
-func NewScanStr(table string, families map[string][]string, startRow, stoprow *[]byte) *Scan {
-	return &Scan{
+func NewScanStr(table string, families map[string][]string, startRow, stopRow []byte) *Scan {
+	scan := &Scan{
 		base: base{
 			table: []byte(table),
-			//key:
+			key:   startRow,
 		},
 		families:     families,
 		startRow:     startRow,
 		stopRow:      stopRow,
 		closeScanner: false,
 	}
+	return scan
 }
 
 // NewScanFromId creates a new Scan request that will return additional results
 // from a given scanner Id
-func NewScanFromId(table string, scannerId uint64) {
+func NewScanFromId(table string, scannerId uint64) *Scan {
 	return &Scan{
 		base: base{
 			table: []byte(table),
@@ -58,7 +58,7 @@ func NewScanFromId(table string, scannerId uint64) {
 
 // NewScanCloseId creates a new Scan request that will close the scan for a
 // given scanner Id
-func NewScanCloseId(table string, scannerId uint64) {
+func NewScanCloseId(table string, scannerId uint64) *Scan {
 	return &Scan{
 		base: base{
 			table: []byte(table),
@@ -74,20 +74,18 @@ func (s *Scan) Name() string {
 	return "Scan"
 }
 
+// Serialize will convert this Scan into a serialized protobuf message ready
+// to be sent to an hbase node
 func (s *Scan) Serialize() ([]byte, error) {
 	scan := &pb.ScanRequest{
 		Region:       s.regionSpecifier(),
-		CloseScanner: s.closeScanner,
+		CloseScanner: &s.closeScanner,
 	}
-	if scannerId == nil {
+	if s.scannerId == nil {
 		scan.Scan = &pb.Scan{
-			Column: familiesToColumn(s.families),
-		}
-		if s.startRow != nil {
-			scan.Scan.StartRow = *s.startRow
-		}
-		if s.stopRow != nil {
-			scan.Scan.StopRow = *s.StopRow
+			Column:   familiesToColumn(s.families),
+			StartRow: s.startRow,
+			StopRow:  s.stopRow,
 		}
 	} else {
 		scan.ScannerId = s.scannerId
@@ -100,4 +98,3 @@ func (s *Scan) Serialize() ([]byte, error) {
 func (s *Scan) NewResponse() proto.Message {
 	return &pb.ScanResponse{}
 }
-*/

--- a/hrpc/scan.go
+++ b/hrpc/scan.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2015  The GoHBase Authors.  All rights reserved.
+// This file is part of GoHBase.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+package hrpc
+
+/*
+import (
+	"github.com/golang/protobuf/proto"
+	"github.com/tsuna/gohbase/pb"
+)
+
+// Get represents a Get HBase call.
+type Scan struct {
+	base
+
+	families map[string][]string //Maps a column family to a list of qualifiers
+
+	closeScanner bool
+
+	startRow []byte
+	stopRow  []byte
+
+	scannerId *uint64
+}
+
+// NewScanStr creates a new Scan request that will start a scan for rows between
+// startRow (inclusive) and stopRow (exclusive). The values in the specified
+// column families and qualifiers will be returned. When run, a scanner Id will
+// also be returned, that can be used to fetch addition results via successive
+// Scan requests.
+func NewScanStr(table string, families map[string][]string, startRow, stoprow *[]byte) *Scan {
+	return &Scan{
+		base: base{
+			table: []byte(table),
+			//key:
+		},
+		families:     families,
+		startRow:     startRow,
+		stopRow:      stopRow,
+		closeScanner: false,
+	}
+}
+
+// NewScanFromId creates a new Scan request that will return additional results
+// from a given scanner Id
+func NewScanFromId(table string, scannerId uint64) {
+	return &Scan{
+		base: base{
+			table: []byte(table),
+			//key:
+		},
+		scannerId:    &scannerId,
+		closeScanner: false,
+	}
+}
+
+// NewScanCloseId creates a new Scan request that will close the scan for a
+// given scanner Id
+func NewScanCloseId(table string, scannerId uint64) {
+	return &Scan{
+		base: base{
+			table: []byte(table),
+			//key:
+		},
+		scannerId:    &scannerId,
+		closeScanner: true,
+	}
+}
+
+// Name returns the name of this RPC call.
+func (s *Scan) Name() string {
+	return "Scan"
+}
+
+func (s *Scan) Serialize() ([]byte, error) {
+	scan := &pb.ScanRequest{
+		Region:       s.regionSpecifier(),
+		CloseScanner: s.closeScanner,
+	}
+	if scannerId == nil {
+		scan.Scan = &pb.Scan{
+			Column: familiesToColumn(s.families),
+		}
+		if s.startRow != nil {
+			scan.Scan.StartRow = *s.startRow
+		}
+		if s.stopRow != nil {
+			scan.Scan.StopRow = *s.StopRow
+		}
+	} else {
+		scan.ScannerId = s.scannerId
+	}
+	return proto.Marshal(scan)
+}
+
+// NewResponse creates an empty protobuf message to read the response of this
+// RPC.
+func (s *Scan) NewResponse() proto.Message {
+	return &pb.ScanResponse{}
+}
+*/

--- a/region/client.go
+++ b/region/client.go
@@ -16,7 +16,9 @@ import (
 )
 
 var (
-	ShortWriteErr = fmt.Errorf("short write occurred while writing to socket")
+	// This error is used when the writer thread only succeeds in writing part
+	// of its buffer to the socket, and there is data that was not sent
+	ErrShortWrite = fmt.Errorf("short write occurred while writing to socket")
 )
 
 // Client manages a connection to a RegionServer.
@@ -76,7 +78,7 @@ func (c *Client) write() {
 		if n != len(buf) {
 			// We failed to write the entire buffer
 			// TODO: Perhaps handle this in another way than closing down
-			c.sendErr = ShortWriteErr
+			c.sendErr = ErrShortWrite
 			close(c.done)
 			return
 		}

--- a/region/client.go
+++ b/region/client.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	// This error is used when the writer thread only succeeds in writing part
-	// of its buffer to the socket, and there is data that was not sent
+	// ErrShortWrite is used when the writer thread only succeeds in writing
+	// part of its buffer to the socket, and not all of the buffer was sent
 	ErrShortWrite = fmt.Errorf("short write occurred while writing to socket")
 )
 

--- a/region/client.go
+++ b/region/client.go
@@ -26,6 +26,11 @@ type Client struct {
 
 	// Port of the RegionServer.
 	port uint16
+
+	// Channels to send messages to the writer thread
+	sendBuf  chan []byte
+	sendDone chan int
+	sendErr  error
 }
 
 // NewClient creates a new RegionClient.
@@ -37,10 +42,13 @@ func NewClient(host string, port uint16) (*Client, error) {
 			fmt.Errorf("failed to connect to the RegionServer at %s: %s", addr, err)
 	}
 	c := &Client{
-		conn: conn,
-		host: host,
-		port: port,
+		conn:     conn,
+		host:     host,
+		port:     port,
+		sendBuf:  make(chan []byte),
+		sendDone: make(chan int),
 	}
+	go c.write()
 	err = c.sendHello()
 	if err != nil {
 		return nil, err
@@ -48,16 +56,26 @@ func NewClient(host string, port uint16) (*Client, error) {
 	return c, nil
 }
 
-// Sends the given buffer to the RegionServer.
-func (c *Client) write(buf []byte) error {
-	// TODO: Handle short writes.
-	n, err := c.conn.Write(buf)
-	if err != nil {
-		return fmt.Errorf("Failed to write to the RS: %s", err)
-	} else if n != len(buf) {
-		return fmt.Errorf("Failed to write everything to the RS: %s", err)
+// Reads buffers from c.sendBuf, and writes then to the RegionServer. If an
+// error is encountered, closes c.sendDone to let writers to c.sendBuf to know
+// that they should give up.
+func (c *Client) write() {
+	for {
+		buf := <-c.sendBuf
+		n, err := c.conn.Write(buf)
+		if err != nil {
+			// There was an error while writing
+			c.sendErr = fmt.Errorf("error while writing to socket: %v", err)
+			close(c.sendDone)
+			return
+		} else if n != len(buf) {
+			// We failed to write the entire buffer
+			// TODO: Perhaps handle this in another way than closing down
+			c.sendErr = fmt.Errorf("short write occurred while writing to socket")
+			close(c.sendDone)
+			return
+		}
 	}
-	return nil
 }
 
 // Tries to read enough data to fully fill up the given buffer.
@@ -93,7 +111,12 @@ func (c *Client) sendHello() error {
 	binary.BigEndian.PutUint32(buf[6:], uint32(len(data)))
 	buf = append(buf, data...)
 
-	return c.write(buf)
+	select {
+	case c.sendBuf <- buf:
+		return nil
+	case <-c.sendDone:
+		return c.sendErr
+	}
 }
 
 // SendRPC sends an RPC out to the wire.
@@ -125,9 +148,10 @@ func (c *Client) SendRPC(rpc hrpc.Call) (proto.Message, error) {
 	buf = append(buf, payloadLen...)
 	buf = append(buf, payload...)
 
-	err = c.write(buf)
-	if err != nil {
-		return nil, err
+	select {
+	case <-c.sendDone:
+		return nil, c.sendErr
+	case c.sendBuf <- buf:
 	}
 
 	var sz [4]byte


### PR DESCRIPTION
This PR changes region/client.go to have a separate writer thread for each client. When a thread wishes to write, it writes its buffer to an unbuffered channel that the writer thread is reading from. If the writer encounters an error, it closes the done channel, which all threads that are writing to the send channel will be watching. Upon the done channel being closed, threads consult sendErr for the reason. The sendWrite function implements the intended behavior for functions wishing to write a buffer.