### PR TITLE
Added Scanner.ScanCh for creating a channel to consume rows as they a re scanned.

### DIFF
--- a/hrpc/scan.go
+++ b/hrpc/scan.go
@@ -37,6 +37,10 @@ const (
 // Scanner will be automatically closed if there's no more data to read,
 // otherwise Close method should be called.
 type Scanner interface {
+	// ScanCh returns a channel for consuming rows as they are scanned. If an error is
+	// encountered, that row is skipped and the error is ignored. This method should only
+	// be used if errors are not a concern.
+	ScanCh() <-chan *Result
 	// Next returns a row at a time.
 	// Once all rows are returned, subsequent calls will return nil and io.EOF.
 	//

--- a/scanner.go
+++ b/scanner.go
@@ -19,7 +19,10 @@ import (
 	"github.com/tsuna/gohbase/pb"
 )
 
-const noScannerID = math.MaxUint64
+const (
+	noScannerID      = math.MaxUint64
+	scanChBufferSize = 256
+)
 
 type re struct {
 	rs []*pb.Result
@@ -110,6 +113,25 @@ func toLocalResult(r *pb.Result) *hrpc.Result {
 		return nil
 	}
 	return hrpc.ToLocalResult(r)
+}
+
+// ScanCh returns a channel for consuming rows as they are scanned. If an error is
+// encountered, that row is skipped and the error is ignored. This method should only
+// be used if errors are not a concern.
+func (s *scanner) ScanCh() <-chan *hrpc.Result {
+	ch := make(chan *hrpc.Result, scanChBufferSize)
+	go func() {
+		defer close(ch)
+		defer s.Close()
+		var row *hrpc.Result
+		var err error
+		for err == nil {
+			if row, err = s.Next(); err == nil {
+				ch <- row
+			}
+		}
+	}()
+	return ch
 }
 
 // Next returns a row at a time.


### PR DESCRIPTION
ScanCh is a convenience method for retrieving a buffered channel that can be used to consume rows as they are scanned. As the comment mentions, errors are swallowed and this should only be used when you don't really care about errors.

As a potential enhancement, ```ScanCh``` could take a variadic argument of callback functions for when an error is found. This would allow us to gain the benefit of error handling as well as the convenience of a channel. This is an idiom that I didn't see elsewhere in the codebase, however, so I wanted to check with everyone before implementing it.