### PR TITLE
Expose reversed option on scan

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -273,6 +273,7 @@ func (f *fetcher) next() (*pb.ScanResponse, hrpc.RegionInfo, error) {
 			hrpc.NumberOfRows(f.rpc.NumberOfRows()),
 			hrpc.MaxResultsPerColumnFamily(f.rpc.MaxResultsPerColumnFamily()),
 			hrpc.ResultOffset(f.rpc.ResultOffset()),
+			hrpc.SetReversed(f.rpc.Reversed()),
 		)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
Useful scan functionality especially when a zero padded timestamp is part of a row key so that you can retrieve rows in reverse order.