### PR TITLE
Implement reverse scanner

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -47,7 +47,10 @@ func CreateTable(client gohbase.AdminClient, table string, cFamilies []string) e
 	for _, f := range cFamilies {
 		cf[f] = nil
 	}
-	ct := hrpc.NewCreateTable(context.Background(), []byte(table), cf)
+
+	// pre-split table for reverse scan test of region changes
+	keySplits := [][]byte{[]byte("REVTEST-100"), []byte("REVTEST-200"), []byte("REVTEST-300")}
+	ct := hrpc.NewCreateTable(context.Background(), []byte(table), cf, hrpc.SplitKeys(keySplits))
 	if err := client.CreateTable(ct); err != nil {
 		return err
 	}
@@ -1869,4 +1872,95 @@ func TestMultiRequest(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+func TestReverseScan(t *testing.T) {
+	c := gohbase.NewClient(*host)
+	defer c.Close()
+
+	baseErr := "Reverse Scan error "
+
+	values := make(map[string]map[string][]byte)
+	values["cf"] = map[string][]byte{}
+
+	// Save 500 rows
+	for i := 0; i < 500; i++ {
+		key := fmt.Sprintf("REVTEST-%03d", i)
+		values["cf"]["reversetest"] = []byte(fmt.Sprintf("%d", i))
+		putRequest, err := hrpc.NewPutStr(context.Background(), table, key, values)
+		if err != nil {
+			t.Errorf(baseErr+"building put string: %s", err)
+
+		}
+
+		_, err = c.Put(putRequest)
+		if err != nil {
+			t.Errorf(baseErr+"saving row: %s", err)
+		}
+	}
+
+	// Read them back in reverse order
+	scanRequest, err := hrpc.NewScanRangeStr(context.Background(),
+		table,
+		"REVTEST-999",
+		"REVTEST-",
+		hrpc.Families(map[string][]string{"cf": []string{"reversetest"}}),
+		hrpc.Reversed(),
+	)
+	if err != nil {
+		t.Errorf(baseErr+"setting up reverse scan: %s", err)
+	}
+	i := 0
+	results := c.Scan(scanRequest)
+	for {
+		r, err := results.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Errorf(baseErr+"scanning results: %s", err)
+		}
+		i++
+		expected := fmt.Sprintf("%d", 500-i)
+		if string(r.Cells[0].Value) != expected {
+			t.Errorf(baseErr + "- unexpected rowkey returned")
+		}
+	}
+	if i != 500 {
+		t.Errorf(baseErr+" expected 500 rows returned; found %d", i)
+	}
+	results.Close()
+
+	// Read part of them back in reverse order. Stoprow should be exclusive just like forward scan
+	scanRequest, err = hrpc.NewScanRangeStr(context.Background(),
+		table,
+		"REVTEST-250",
+		"REVTEST-150",
+		hrpc.Families(map[string][]string{"cf": []string{"reversetest"}}),
+		hrpc.Reversed(),
+	)
+	if err != nil {
+		t.Errorf(baseErr+"setting up reverse scan: %s", err)
+	}
+	i = 0
+	results = c.Scan(scanRequest)
+	for {
+		r, err := results.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Errorf(baseErr+"scanning results: %s", err)
+		}
+		i++
+		expected := fmt.Sprintf("%d", 251-i)
+		if string(r.Cells[0].Value) != expected {
+			t.Errorf(baseErr + "- unexpected rowkey returned when doing partial reverse scan")
+		}
+	}
+	if i != 100 {
+		t.Errorf(baseErr+" expected 100 rows returned; found %d", i)
+	}
+	results.Close()
+
 }


### PR DESCRIPTION
HBase offers reverse scanning functionality which can be very useful with time series keys. 

Initial attempt did not change regions correctly, but after reviewing the java code for this, I think this is handling region changes in a similar way.

Included integration tests with the test table pre-split for my test data ranges.