### PR TITLE
using recommended lowercase reference to logrus

### DIFF
--- a/admin_client.go
+++ b/admin_client.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"
 	"github.com/tsuna/gohbase/region"

--- a/caches.go
+++ b/caches.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/cznic/b"
 	"github.com/tsuna/gohbase/hrpc"
 )

--- a/caches.go
+++ b/caches.go
@@ -10,8 +10,8 @@ import (
 	"io"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/cznic/b"
+	log "github.com/sirupsen/logrus"
 	"github.com/tsuna/gohbase/hrpc"
 )
 

--- a/client.go
+++ b/client.go
@@ -12,9 +12,9 @@ import (
 
 	"golang.org/x/time/rate"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/cznic/b"
 	"github.com/golang/protobuf/proto"
+	log "github.com/sirupsen/logrus"
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"
 	"github.com/tsuna/gohbase/region"

--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@ import (
 
 	"golang.org/x/time/rate"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/cznic/b"
 	"github.com/golang/protobuf/proto"
 	"github.com/tsuna/gohbase/hrpc"

--- a/integration_test.go
+++ b/integration_test.go
@@ -22,7 +22,7 @@ import (
 
 	"math"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/tsuna/gohbase"
 	"github.com/tsuna/gohbase/filter"
 	"github.com/tsuna/gohbase/hrpc"

--- a/region/client.go
+++ b/region/client.go
@@ -15,7 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/tsuna/gohbase/hrpc"

--- a/rpc.go
+++ b/rpc.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/region"

--- a/rpc.go
+++ b/rpc.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
+	log "github.com/sirupsen/logrus"
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/region"
 	"github.com/tsuna/gohbase/zk"

--- a/scanner.go
+++ b/scanner.go
@@ -13,7 +13,7 @@ import (
 	"math"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"

--- a/scanner.go
+++ b/scanner.go
@@ -13,8 +13,8 @@ import (
 	"math"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
+	log "github.com/sirupsen/logrus"
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"
 )

--- a/zk/client.go
+++ b/zk/client.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/samuel/go-zookeeper/zk"


### PR DESCRIPTION
Logrus authors recommend that references to the logrus package use only the lowercase variation. See https://github.com/sirupsen/logrus/blob/master/README.md

End user code will not build unless that code and all of its dependencies follow only a single logrus case convention.