### PR TITLE
Fixed a couple linting issues.

### DIFF
--- a/client.go
+++ b/client.go
@@ -58,6 +58,7 @@ type RPCClient interface {
 	SendRPC(rpc hrpc.Call) (proto.Message, error)
 }
 
+// Option is a function used to configure optional config items for a Client.
 type Option func(*client)
 
 // A Client provides access to an HBase cluster.

--- a/rpc.go
+++ b/rpc.go
@@ -581,9 +581,8 @@ func sleepAndIncreaseBackoff(ctx context.Context, backoff time.Duration) (time.D
 	// TODO: Revisit how we back off here.
 	if backoff < 5000*time.Millisecond {
 		return backoff * 2, nil
-	} else {
-		return backoff + 5000*time.Millisecond, nil
 	}
+	return backoff + 5000*time.Millisecond, nil
 }
 
 func (c *client) establishRegionClient(reg hrpc.RegionInfo,


### PR DESCRIPTION
@timoha this fixes a couple lint issues. Unfortunately there are still two instances that golint complains about, even after these changes, but I cannot fix them without breaking backwards compatibility. This is, however, super annoying as most IDEs will show squiggles under these files because of it.

The remaining lint issues are:
```
client.go:156:6: func RpcQueueSize should be RPCQueueSize
rpc.go:37:2: error var TableNotFound should have name of the form ErrFoo
```

I understand that changing these would break backwards compatibility, but since vendoring is the norm in Go, I am wondering if we can make an exception just this once and make these changes?

At the very least, I would request that linting is run automatically going forward. Perhaps we can integrate it into the CI system?