### PR TITLE
hrpc: forward hrpc.Cell stringer to protobuf

### DIFF
--- a/hrpc/call.go
+++ b/hrpc/call.go
@@ -168,6 +168,10 @@ func (b *base) ResultChan() chan RPCResult {
 // Represents a single cell in HBase (a row will have one cell for every qualifier).
 type Cell pb.Cell
 
+func (c *Cell) String() string {
+	return (*pb.Cell)(c).String()
+}
+
 // cellFromCellBlock deserializes a cell from a reader
 func cellFromCellBlock(b []byte) (*pb.Cell, uint32, error) {
 	if len(b) < 4 {

--- a/hrpc/hrpc_test.go
+++ b/hrpc/hrpc_test.go
@@ -614,6 +614,21 @@ func TestMutate(t *testing.T) {
 	}
 }
 
+func TestCellStringer(t *testing.T) {
+	example := Cell{
+		Row:       []byte("r"),
+		Family:    []byte("f"),
+		Qualifier: []byte("q"),
+		Timestamp: proto.Uint64(42),
+		Value:     []byte("Stringer!"),
+	}
+	want := `row:"r" family:"f" qualifier:"q" timestamp:42 value:"Stringer!" `
+	got := example.String()
+	if got != want {
+		t.Errorf("Stringer produced wrong result.  Want %q, got %q", want, got)
+	}
+}
+
 var expectedCells = []*pb.Cell{
 	&pb.Cell{
 		Row:       []byte("row7"),


### PR DESCRIPTION
Forward the stringer so that hrpc.Cell can be displayed in
diagnostic/error messages.