### PR TITLE
hrpc, gohbase: Add snapshot restoration

### DIFF
--- a/hrpc/snapshot.go
+++ b/hrpc/snapshot.go
@@ -198,3 +198,47 @@ func (sr *ListSnapshots) NewResponse() proto.Message {
 func (sr *ListSnapshots) ToProto() proto.Message {
 	return &pb.GetCompletedSnapshotsRequest{}
 }
+
+// RestoreSnapshot represents a RestoreSnapshot HBase call.
+type RestoreSnapshot struct {
+	*Snapshot
+}
+
+// NewRestoreSnapshot creates a new RestoreSnapshot request that will delete
+// the given snapshot.
+func NewRestoreSnapshot(t *Snapshot) *RestoreSnapshot {
+	return &RestoreSnapshot{t}
+}
+
+// Name returns the name of this RPC call.
+func (sr *RestoreSnapshot) Name() string {
+	return "RestoreSnapshot"
+}
+
+// NewResponse creates an empty protobuf message to read the response of this
+// RPC.
+func (sr *RestoreSnapshot) NewResponse() proto.Message {
+	return &pb.RestoreSnapshotResponse{}
+}
+
+// RestoreSnapshotDone represents an IsRestoreSnapshotDone HBase call.
+type RestoreSnapshotDone struct {
+	*Snapshot
+}
+
+// NewRestoreSnapshotDone creates a new RestoreSnapshotDone request that will check if
+// the given snapshot has been complete.
+func NewRestoreSnapshotDone(t *Snapshot) *RestoreSnapshotDone {
+	return &RestoreSnapshotDone{t}
+}
+
+// Name returns the name of this RPC call.
+func (sr *RestoreSnapshotDone) Name() string {
+	return "IsRestoreSnapshotDone"
+}
+
+// NewResponse creates an empty protobuf message to read the response of this
+// RPC.
+func (sr *RestoreSnapshotDone) NewResponse() proto.Message {
+	return &pb.IsRestoreSnapshotDoneResponse{}
+}

--- a/test/mock/adming_client.go
+++ b/test/mock/adming_client.go
@@ -147,3 +147,17 @@ func (mr *MockAdminClientMockRecorder) ListSnapshots(arg0 interface{}) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSnapshots", reflect.TypeOf((*MockAdminClient)(nil).ListSnapshots), arg0)
 }
+
+// RestoreSnapshot mocks base method
+func (m *MockAdminClient) RestoreSnapshot(arg0 *hrpc.Snapshot) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestoreSnapshot", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RestoreSnapshot indicates an expected call of RestoreSnapshot
+func (mr *MockAdminClientMockRecorder) RestoreSnapshot(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreSnapshot", reflect.TypeOf((*MockAdminClient)(nil).RestoreSnapshot), arg0)
+}


### PR DESCRIPTION
One design decision here was to use leave it up to clients to disable & re-enable the table which is required for restoring a snapshot. An alternative option is to handle that in the function call. Let me know if you think it's better to go with the alternative.