### PR TITLE
hrpc: expose CacheBlocks option for scan/get queries

### DIFF
--- a/hrpc/call.go
+++ b/hrpc/call.go
@@ -97,6 +97,7 @@ type hasQueryOptions interface {
 	setMaxVersions(versions uint32)
 	setMaxResultsPerColumnFamily(maxresults uint32)
 	setResultOffset(offset uint32)
+	setCacheBlocks(cacheBlocks bool)
 }
 
 // RPCResult is struct that will contain both the resulting message from an RPC

--- a/hrpc/get.go
+++ b/hrpc/get.go
@@ -105,6 +105,9 @@ func (g *Get) ToProto() proto.Message {
 	if g.existsOnly {
 		get.Get.ExistenceOnly = proto.Bool(true)
 	}
+	if g.cacheBlocks != DefaultCacheBlocks {
+		get.Get.CacheBlocks = &g.cacheBlocks
+	}
 	get.Get.Filter = g.filter
 	return get
 }

--- a/hrpc/hrpc_test.go
+++ b/hrpc/hrpc_test.go
@@ -68,10 +68,6 @@ func TestNewGet(t *testing.T) {
 	if err != nil && errStr != err.Error() || err == nil {
 		t.Errorf("Get8 Expected: %#v\nReceived: %#v", errStr, err)
 	}
-	_, err = NewGet(ctx, tableb, keyb, CacheBlocks(false))
-	if err != nil {
-		t.Errorf("Get9 didn't set attributes correctly.")
-	}
 }
 
 func confirmGetAttributes(ctx context.Context, g *Get, table, key []byte,

--- a/hrpc/hrpc_test.go
+++ b/hrpc/hrpc_test.go
@@ -86,6 +86,129 @@ func confirmGetAttributes(ctx context.Context, g *Get, table, key []byte,
 	return true
 }
 
+func TestGetToProto(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		keyStr = "key"
+		key    = []byte("key")
+		rs     = &pb.RegionSpecifier{
+			Type:  pb.RegionSpecifier_REGION_NAME.Enum(),
+			Value: []byte("region"),
+		}
+		fil = filter.NewList(filter.MustPassAll, filter.NewKeyOnlyFilter(false))
+		fam = map[string][]string{"cookie": []string{"got", "it"}}
+	)
+
+	tests := []struct {
+		g        *Get
+		expProto *pb.GetRequest
+	}{
+		{
+			g: func() *Get {
+				get, _ := NewGetStr(ctx, "", keyStr)
+				return get
+			}(),
+			expProto: &pb.GetRequest{
+				Region: rs,
+				Get: &pb.Get{
+					Row:       key,
+					Column:    []*pb.Column{},
+					TimeRange: &pb.TimeRange{},
+				},
+			},
+		},
+		{ // explicitly set configurable attributes to default values
+			g: func() *Get {
+				get, _ := NewGetStr(ctx, "", keyStr,
+					MaxResultsPerColumnFamily(DefaultMaxResultsPerColumnFamily),
+					ResultOffset(0),
+					MaxVersions(DefaultMaxVersions),
+					CacheBlocks(DefaultCacheBlocks),
+					TimeRangeUint64(MinTimestamp, MaxTimestamp),
+				)
+				return get
+			}(),
+			expProto: &pb.GetRequest{
+				Region: rs,
+				Get: &pb.Get{
+					Row:         key,
+					Column:      []*pb.Column{},
+					TimeRange:   &pb.TimeRange{},
+					StoreLimit:  nil,
+					StoreOffset: nil,
+					MaxVersions: nil,
+					CacheBlocks: nil,
+				},
+			},
+		},
+		{ // set configurable options to non-default values
+			g: func() *Get {
+				get, _ := NewGetStr(ctx, "", keyStr,
+					MaxResultsPerColumnFamily(22),
+					ResultOffset(7),
+					MaxVersions(4),
+					CacheBlocks(!DefaultCacheBlocks),
+					TimeRangeUint64(3456, 6789),
+				)
+				return get
+			}(),
+			expProto: &pb.GetRequest{
+				Region: rs,
+				Get: &pb.Get{
+					Row:    key,
+					Column: []*pb.Column{},
+					TimeRange: &pb.TimeRange{
+						From: proto.Uint64(3456),
+						To:   proto.Uint64(6789),
+					},
+					StoreLimit:  proto.Uint32(22),
+					StoreOffset: proto.Uint32(7),
+					MaxVersions: proto.Uint32(4),
+					CacheBlocks: proto.Bool(!DefaultCacheBlocks),
+				},
+			},
+		},
+		{ // set Filters, Families, and ExistenceOnly
+			g: func() *Get {
+				get, _ := NewGetStr(ctx, "", keyStr,
+					Filters(fil),
+					Families(fam),
+				)
+				get.ExistsOnly()
+				return get
+			}(),
+			expProto: func() *pb.GetRequest {
+				pbFilter, _ := fil.ConstructPBFilter()
+				return &pb.GetRequest{
+					Region: rs,
+					Get: &pb.Get{
+						Row:           key,
+						Column:        familiesToColumn(fam),
+						TimeRange:     &pb.TimeRange{},
+						ExistenceOnly: proto.Bool(true),
+						Filter:        pbFilter,
+					},
+				}
+			}(),
+		},
+	}
+
+	for i, tcase := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			tcase.g.SetRegion(mockRegionInfo([]byte("region")))
+			p := tcase.g.ToProto()
+			out, ok := p.(*pb.GetRequest)
+			if !ok {
+				t.Fatalf("f")
+			}
+			if !proto.Equal(out, tcase.expProto) {
+				t.Fatalf("expected %+v, got %+v", tcase.expProto, out)
+			}
+		})
+
+	}
+}
+
 func TestNewScan(t *testing.T) {
 	ctx := context.Background()
 	table := "test"

--- a/hrpc/hrpc_test.go
+++ b/hrpc/hrpc_test.go
@@ -164,7 +164,7 @@ func TestGetToProto(t *testing.T) {
 				},
 			},
 		},
-		{ // set Filters, Families, and ExistenceOnly
+		{ // set filters, families, and existenceOnly
 			g: func() *Get {
 				get, _ := NewGetStr(ctx, "", keyStr,
 					Filters(fil),
@@ -415,7 +415,7 @@ func TestScanToProto(t *testing.T) {
 				},
 			},
 		},
-		{
+		{ // set filters and families
 			s: func() *Scan {
 				s, _ := NewScanStr(ctx, "", Filters(fil), Families(fam))
 				return s

--- a/hrpc/hrpc_test.go
+++ b/hrpc/hrpc_test.go
@@ -68,6 +68,10 @@ func TestNewGet(t *testing.T) {
 	if err != nil && errStr != err.Error() || err == nil {
 		t.Errorf("Get8 Expected: %#v\nReceived: %#v", errStr, err)
 	}
+	_, err = NewGet(ctx, tableb, keyb, CacheBlocks(false))
+	if err != nil {
+		t.Errorf("Get9 didn't set attributes correctly.")
+	}
 }
 
 func confirmGetAttributes(ctx context.Context, g *Get, table, key []byte,

--- a/hrpc/mutate.go
+++ b/hrpc/mutate.go
@@ -444,7 +444,7 @@ func (m *Mutate) valuesToCellblocks() ([][]byte, int32, uint32) {
 			cellblock, sz := toCellblock(m.key, family, []byte(k1), v1, ts, mt)
 			cellblocks = append(cellblocks, cellblock...)
 			size += sz
-			count += 1
+			count++
 		}
 	}
 	return cellblocks, int32(count), size

--- a/hrpc/query.go
+++ b/hrpc/query.go
@@ -23,6 +23,7 @@ type baseQuery struct {
 	maxVersions   uint32
 	storeLimit    uint32
 	storeOffset   uint32
+	cacheBlocks   bool
 }
 
 // newBaseQuery return baseQuery with all default values
@@ -32,6 +33,7 @@ func newBaseQuery() baseQuery {
 		fromTimestamp: MinTimestamp,
 		toTimestamp:   MaxTimestamp,
 		maxVersions:   DefaultMaxVersions,
+		cacheBlocks:   DefaultCacheBlocks,
 	}
 }
 
@@ -53,6 +55,9 @@ func (bq *baseQuery) setMaxResultsPerColumnFamily(maxresults uint32) {
 }
 func (bq *baseQuery) setResultOffset(offset uint32) {
 	bq.storeOffset = offset
+}
+func (bq *baseQuery) setCacheBlocks(cacheBlocks bool) {
+	bq.cacheBlocks = cacheBlocks
 }
 
 // Families option adds families constraint to a Scan or Get request.
@@ -149,5 +154,17 @@ func ResultOffset(offset uint32) func(Call) error {
 			return nil
 		}
 		return errors.New("'ResultOffset' option can only be used with Get or Scan request")
+	}
+}
+
+// CacheBlocks is an option for Scan or Get requests to enable/disable the block cache
+// for the request
+func CacheBlocks(cacheBlocks bool) func(Call) error {
+	return func(hc Call) error {
+		if c, ok := hc.(hasQueryOptions); ok {
+			c.setCacheBlocks(cacheBlocks)
+			return nil
+		}
+		return errors.New("'CacheBlocks' option can only be used with Get or Scan request")
 	}
 }

--- a/hrpc/query_test.go
+++ b/hrpc/query_test.go
@@ -161,3 +161,50 @@ func TestResultOffset(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestCacheBlocks(t *testing.T) {
+	// set CacheBlocks to false for Get
+	g, err := NewGet(context.Background(), nil, nil, CacheBlocks(false))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if cbExp, cbGot := false, g.cacheBlocks; cbExp != cbGot {
+		t.Errorf("expected %v, got %v", cbExp, cbGot)
+	}
+
+	// check that default CacheBlocks for Get is true
+	g2, err := NewGet(context.Background(), nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if cbExp, cbGot := true, g2.cacheBlocks; cbExp != cbGot {
+		t.Errorf("expected %v, got %v", cbExp, cbGot)
+	}
+
+	// explicitly set CacheBlocks to true for Get
+	s, err := NewScan(context.Background(), nil, CacheBlocks(true))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if cbExp, cbGot := true, s.cacheBlocks; cbExp != cbGot {
+		t.Errorf("expected %v, got %v", cbExp, cbGot)
+	}
+
+	// check that default CacheBlocks for Scan is true
+	s2, err := NewScan(context.Background(), nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if cbExp, cbGot := true, s2.cacheBlocks; cbExp != cbGot {
+		t.Errorf("expected %v, got %v", cbExp, cbGot)
+	}
+
+	_, err = NewPutStr(context.Background(), "", "", nil, CacheBlocks(true))
+	if err == nil || err.Error() !=
+		"'CacheBlocks' option can only be used with Get or Scan request" {
+		t.Error(err)
+	}
+}

--- a/hrpc/scan.go
+++ b/hrpc/scan.go
@@ -31,6 +31,8 @@ const (
 	// DefaultMaxResultsPerColumnFamily is the default max number of cells fetched
 	// per column family for each row
 	DefaultMaxResultsPerColumnFamily = math.MaxInt32
+	// DefaultCacheBlocks is the default setting to enable the block cache for get/scan queries
+	DefaultCacheBlocks = true
 )
 
 // Scanner is used to read data sequentially from HBase.
@@ -213,6 +215,9 @@ func (s *Scan) ToProto() proto.Message {
 	}
 	if s.reversed {
 		scan.Scan.Reversed = &s.reversed
+	}
+	if s.cacheBlocks != DefaultCacheBlocks {
+		scan.Scan.CacheBlocks = &s.cacheBlocks
 	}
 	scan.Scan.Filter = s.filter
 	return scan


### PR DESCRIPTION
Client.proto already has this defined as `cache_blocks` in the models for `Get` and `Scan`. This allows users of the hrpc to set the attribute per request.