### PR TITLE
region: fix TestProcessRPCs/2 test

### DIFF
--- a/region/client_test.go
+++ b/region/client_test.go
@@ -733,7 +733,7 @@ func TestProcessRPCs(t *testing.T) {
 			minsent: 1, maxsent: 1},
 		{qsize: 2, interval: 1000 * time.Hour, ncalls: 100, minsent: 50, maxsent: 50},
 		{qsize: 100, interval: 0 * time.Millisecond, ncalls: 1000,
-			minsent: 10, maxsent: 700, concurrent: true},
+			minsent: 1, maxsent: 1000, concurrent: true},
 	}
 
 	for i, tcase := range tests {


### PR DESCRIPTION
The test was expecting that the scheduler would let
processRPCs goroutine to read several RPCs before moving on
to next goroutine. In case the sheduler lets processRPC to only
process one RPC at a time, we would end up with a call to regionserver
for each RPC (no batching). This can be especially reproduced with
-race flag.

Instead we should expect that at most there would be as many batches
as RPCs.