### PR TITLE
Don't return error on subsequent closing of scanner

### DIFF
--- a/hrpc/scan.go
+++ b/hrpc/scan.go
@@ -50,7 +50,7 @@ type Scanner interface {
 	// Close should be called if it is desired to stop scanning before getting all of results.
 	// If you call Next() after calling Close() you might still get buffered results.
 	// Othwerwise, in case all results have been delivered or in case of an error, the Scanner
-	// will be closed automatically.
+	// will be closed automatically. It's okay to close an already closed scanner.
 	Close() error
 }
 

--- a/scanner.go
+++ b/scanner.go
@@ -251,7 +251,7 @@ func (s *scanner) update(resp *pb.ScanResponse, region hrpc.RegionInfo) {
 
 func (s *scanner) Close() error {
 	if s.closed {
-		return errors.New("scanner has already been closed")
+		return nil
 	}
 	s.closed = true
 	// close the last region scanner


### PR DESCRIPTION
    We are calling Close() on scanner internally when there's no more data,
    the client might also additionally call Close() themselves causing
    unexpected for them error.