### PR TITLE
Expose Mutate.values

### DIFF
--- a/hrpc/mutate.go
+++ b/hrpc/mutate.go
@@ -286,6 +286,14 @@ func (m *Mutate) SkipBatch() bool {
 	return m.skipbatch
 }
 
+// Values returns the internal values object
+// which should be treated as read-only.
+// This would typically be used for calculations
+// related to metrics and workloads
+func (m *Mutate) Values() map[string]map[string][]byte {
+	return m.values
+}
+
 func (m *Mutate) setSkipBatch(v bool) {
 	m.skipbatch = v
 }


### PR DESCRIPTION
This PR adds a function to expose the Mutate object's values field.
It is envisioned that this would aid in estimating the amount of work
that is about to be done (for use in metrics and tracing annotations).