### PR TITLE
region: optimisee decompressCellblocks

### DIFF
--- a/region/compressor.go
+++ b/region/compressor.go
@@ -33,6 +33,16 @@ func growBuffer(b []byte, sz int) []byte {
 	return append(b, make([]byte, sz)...)
 }
 
+func resizeBufferCap(b []byte, capacity int) []byte {
+	if capacity <= cap(b) {
+		return b
+	}
+
+	l := len(b)
+	b = append(b, make([]byte, capacity-l)...)
+	return b[:l]
+}
+
 func (c *compressor) compressCellblocks(cbs net.Buffers, uncompressedLen uint32) []byte {
 	b := newBuffer(4)
 
@@ -111,6 +121,8 @@ func (c *compressor) decompressCellblocks(b []byte) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read uncompressed block length: %w", err)
 		}
+
+		out = resizeBufferCap(out, len(out)+int(uncompressedBlockLen))
 
 		// read and decompress encoded chunks until whole block is read
 		var uncompressedSoFar uint32


### PR DESCRIPTION
Pre-allocating the output buffer drastically reduce the number of allocations made (and thus, the number of garbage object created):
```
name                                     old time/op    new time/op    delta
DecompressCellblocks1/BlockLen10-12        42.2ns ± 0%    43.2ns ± 1%   +2.40%  (p=0.016 n=4+5)
DecompressCellblocks1/BlockLen100-12        244ns ± 4%     168ns ± 0%  -31.29%  (p=0.008 n=5+5)
DecompressCellblocks1/BlockLen1000-12      1.68µs ± 1%    1.33µs ± 3%  -21.07%  (p=0.008 n=5+5)
DecompressCellblocks1/BlockLen10000-12     19.2µs ± 5%    12.9µs ± 3%  -32.77%  (p=0.008 n=5+5)
DecompressCellblocks10/BlockLen10-12        288ns ± 2%     300ns ± 1%   +4.28%  (p=0.008 n=5+5)
DecompressCellblocks10/BlockLen100-12      1.78µs ± 1%    1.98µs ± 1%  +11.34%  (p=0.008 n=5+5)
DecompressCellblocks10/BlockLen1000-12     19.4µs ± 5%    17.9µs ± 1%   -7.77%  (p=0.008 n=5+5)
DecompressCellblocks10/BlockLen10000-12     181µs ± 1%     168µs ± 3%   -7.33%  (p=0.016 n=4+5)

name                                     old alloc/op   new alloc/op   delta
DecompressCellblocks1/BlockLen10-12         16.0B ± 0%     16.0B ± 0%     ~     (all equal)
DecompressCellblocks1/BlockLen100-12         240B ± 0%      112B ± 0%  -53.33%  (p=0.008 n=5+5)
DecompressCellblocks1/BlockLen1000-12      2.03kB ± 0%    1.02kB ± 0%  -49.61%  (p=0.008 n=5+5)
DecompressCellblocks1/BlockLen10000-12     48.5kB ± 0%    10.2kB ± 0%  -78.88%  (p=0.008 n=5+5)
DecompressCellblocks10/BlockLen10-12         240B ± 0%      240B ± 0%     ~     (all equal)
DecompressCellblocks10/BlockLen100-12      2.03kB ± 0%    3.47kB ± 0%  +70.87%  (p=0.008 n=5+5)
DecompressCellblocks10/BlockLen1000-12     48.5kB ± 0%    44.3kB ± 0%   -8.68%  (p=0.008 n=5+5)
DecompressCellblocks10/BlockLen10000-12     506kB ± 0%     457kB ± 0%   -9.71%  (p=0.008 n=5+5)

name                                     old allocs/op  new allocs/op  delta
DecompressCellblocks1/BlockLen10-12          1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecompressCellblocks1/BlockLen100-12         4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
DecompressCellblocks1/BlockLen1000-12        7.00 ± 0%      1.00 ± 0%  -85.71%  (p=0.008 n=5+5)
DecompressCellblocks1/BlockLen10000-12       16.0 ± 0%       1.0 ± 0%  -93.75%  (p=0.008 n=5+5)
DecompressCellblocks10/BlockLen10-12         4.00 ± 0%      4.00 ± 0%     ~     (all equal)
DecompressCellblocks10/BlockLen100-12        7.00 ± 0%      5.00 ± 0%  -28.57%  (p=0.008 n=5+5)
DecompressCellblocks10/BlockLen1000-12       16.0 ± 0%       8.0 ± 0%  -50.00%  (p=0.008 n=5+5)
DecompressCellblocks10/BlockLen10000-12      24.0 ± 0%       8.0 ± 0%  -66.67%  (p=0.008 n=5+5)
```