### PR TITLE
avoid cache avalanche

### DIFF
--- a/client.go
+++ b/client.go
@@ -97,6 +97,10 @@ type client struct {
 		string, time.Duration, compression.Codec) hrpc.RegionClient
 
 	compressionCodec compression.Codec
+
+
+	// region looker lock container
+	regionLookerMap sync.Map
 }
 
 // NewClient creates a new HBase client.


### PR DESCRIPTION
At the beginning of client start, there is no table region info in cache.
If there are many go routine to access a table at same time, they will miss cache and send request package to get table region info.
In this case, too many duplicated requests should be avoid.