### PR TITLE
metrics: add bytes written & bytes read metric

### DIFF
--- a/region/new.go
+++ b/region/new.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tsuna/gohbase/compression"
 	"github.com/tsuna/gohbase/hrpc"
 )
@@ -43,10 +44,19 @@ func (c *client) Dial(ctx context.Context) error {
 	c.dialOnce.Do(func() {
 		var d net.Dialer
 		var err error
+
 		c.conn, err = d.DialContext(ctx, "tcp", c.addr)
 		if err != nil {
 			c.fail(fmt.Errorf("failed to dial RegionServer: %s", err))
 			return
+		}
+
+		// Wrap our connection in a counter to expose prometheus counts for our
+		// connection.
+		c.conn = promMetricConn{
+			c.conn,
+			bytesReadTotal.With(prometheus.Labels{"regionserver": c.addr}),
+			bytesWrittenTotal.With(prometheus.Labels{"regionserver": c.addr}),
 		}
 
 		// time out send hello if it take long


### PR DESCRIPTION
This change adds two new counter vector metrics:

- bytes_read_total - number of bytes read by a regionserver connection 
- bytes_written_total - number of bytes written to a regionserver connection

These metrics have one label - regionserver - which indicates the address of the connection used.