### PR TITLE
Remove context on multis

### DIFF
--- a/region/client.go
+++ b/region/client.go
@@ -6,7 +6,6 @@
 package region
 
 import (
-	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -318,7 +317,7 @@ func (c *client) unregisterRPC(id uint32) hrpc.Call {
 func (c *client) processRPCs() {
 	// TODO: flush when the size is too large
 	// TODO: if multi has only one call, send that call instead
-	m := newMulti(context.Background(), c.rpcQueueSize)
+	m := newMulti(c.rpcQueueSize)
 	defer func() {
 		m.returnResults(nil, ErrClientClosed)
 	}()
@@ -340,7 +339,7 @@ func (c *client) processRPCs() {
 		}
 
 		// Start preparing for the next batch
-		m = newMulti(context.Background(), c.rpcQueueSize)
+		m = newMulti(c.rpcQueueSize)
 	}
 
 	for {

--- a/region/multi.go
+++ b/region/multi.go
@@ -25,8 +25,6 @@ var multiPool = sync.Pool{
 func freeMulti(m *multi) {
 	// Set pointers to nil to allow the objects to be garbage
 	// collected
-
-	// m.ctx = nil Do this after #174 is fixed
 	for i := range m.calls {
 		m.calls[i] = nil
 	}
@@ -38,18 +36,14 @@ func freeMulti(m *multi) {
 }
 
 type multi struct {
-	ctxM sync.Mutex
-	ctx  context.Context
-
 	size  int
 	calls []hrpc.Call
 	// regions preserves the order of regions to match against RegionActionResults
 	regions []hrpc.RegionInfo
 }
 
-func newMulti(ctx context.Context, queueSize int) *multi {
+func newMulti(queueSize int) *multi {
 	m := multiPool.Get().(*multi)
-	m.ctx = ctx
 	m.size = queueSize
 	return m
 }
@@ -320,11 +314,7 @@ func (m *multi) ResultChan() chan hrpc.RPCResult {
 
 // Context is not supported for Multi.
 func (m *multi) Context() context.Context {
-	// TODO: maybe pick the one with the longest deadline and use a context that has that deadline?
-	m.ctxM.Lock()
-	defer m.ctxM.Unlock()
-
-	return m.ctx
+	return context.Background()
 }
 
 // String returns a description of this call
@@ -334,10 +324,7 @@ func (m *multi) String() string {
 
 // SetContext is used for tracing implementations
 func (m *multi) SetContext(ctx context.Context) {
-	m.ctxM.Lock()
-	defer m.ctxM.Unlock()
-
-	m.ctx = ctx
+	panic("not supported")
 }
 
 // Key is not supported for Multi RPC.

--- a/region/multi_test.go
+++ b/region/multi_test.go
@@ -317,7 +317,7 @@ func TestMultiToProto(t *testing.T) {
 
 	for i, tcase := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			m := newMulti(context.Background(), 1000)
+			m := newMulti(1000)
 
 			for _, c := range tcase.calls {
 				if m.add(c) {
@@ -364,7 +364,7 @@ func TestMultiToProto(t *testing.T) {
 			}
 
 			// test cellblocks
-			m = newMulti(context.Background(), 1000)
+			m = newMulti(1000)
 			for _, c := range tcase.calls {
 				if m.add(c) {
 					t.Fatal("multi is full")
@@ -689,7 +689,7 @@ func TestMultiReturnResults(t *testing.T) {
 
 	for i, tcase := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			m := newMulti(context.Background(), 1000)
+			m := newMulti(1000)
 
 			for _, c := range tcase.calls {
 				if m.add(c) {
@@ -983,7 +983,7 @@ func TestMultiDeserializeCellBlocks(t *testing.T) {
 
 	for i, tcase := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			m := newMulti(context.Background(), 1000)
+			m := newMulti(1000)
 
 			for _, c := range tcase.calls {
 				if m.add(c) {
@@ -1023,7 +1023,7 @@ func BenchmarkMultiToProto(b *testing.B) {
 		},
 	}
 
-	m := newMulti(context.Background(), 1000)
+	m := newMulti(1000)
 	var c hrpc.Call
 	c, _ = hrpc.NewGetStr(context.Background(), "reg0", "call0")
 	c.SetRegion(reg0)


### PR DESCRIPTION
It is confusing to have a different span for processRPCs and not likely to be
used by viewers of the data. To track the time an RPC spends in the
processRPCs loop we can add a span to that RPC's context as it enters
the loop and close the span when the RPC is flushed. Though, that has not been implemented here.

Once the span is removed from processRPCs, much of the code related to
open telemetry tracing is no longer needed in the region package.
