### PR TITLE
Optimize multi serialization

### DIFF
--- a/hrpc/checkandput.go
+++ b/hrpc/checkandput.go
@@ -54,7 +54,7 @@ func NewCheckAndPut(put *Mutate, family string,
 
 // ToProto converts the RPC into a protobuf message
 func (cp *CheckAndPut) ToProto() proto.Message {
-	mutateRequest, _, _ := cp.toProto(false)
+	mutateRequest, _, _ := cp.toProto(false, nil)
 	mutateRequest.Condition = &pb.Condition{
 		Row:         cp.key,
 		Family:      cp.family,

--- a/hrpc/hrpc_test.go
+++ b/hrpc/hrpc_test.go
@@ -1296,7 +1296,7 @@ func TestMutate(t *testing.T) {
 		}
 
 		// test cellblocks
-		cellblocksProto, cellblocks, cellblocksLen := m.SerializeCellBlocks()
+		cellblocksProto, cellblocks, cellblocksLen := m.SerializeCellBlocks(nil)
 		mr, ok = cellblocksProto.(*pb.MutateRequest)
 		if !ok {
 			t.Fatal("expected proto be of type *pb.MutateRequest")

--- a/region/client.go
+++ b/region/client.go
@@ -38,7 +38,7 @@ type canDeserializeCellBlocks interface {
 type canSerializeCellBlocks interface {
 	// SerializeCellBlocks serializes RPC into protobuf for metadata
 	// as well as cellblocks for payload.
-	SerializeCellBlocks() (proto.Message, [][]byte, uint32)
+	SerializeCellBlocks([][]byte) (proto.Message, [][]byte, uint32)
 	// CellBlocksEnabled returns true if cellblocks are enabled for this RPC
 	CellBlocksEnabled() bool
 }
@@ -628,7 +628,7 @@ func (c *client) send(rpc hrpc.Call) (uint32, error) {
 
 	if s, ok := rpc.(canSerializeCellBlocks); ok && s.CellBlocksEnabled() {
 		// request can be serialized to cellblocks
-		request, cellblocks, cellblocksLen = s.SerializeCellBlocks()
+		request, cellblocks, cellblocksLen = s.SerializeCellBlocks(nil)
 
 		if c.compressor != nil {
 			// we have compressor, encode the cellblocks

--- a/region/multi.go
+++ b/region/multi.go
@@ -118,7 +118,11 @@ func (m *multi) toProto(isCellblocks bool) (proto.Message, [][]byte, uint32) {
 	ra := make([]*pb.RegionAction, len(actionsPerReg))
 	m.regions = make([]hrpc.RegionInfo, len(actionsPerReg))
 
-	var cellblocks [][]byte
+	var cbCount int
+	for _, as := range actionsPerReg {
+		cbCount += len(as.cellblocks)
+	}
+	cellblocks := make([][]byte, 0, cbCount)
 	i := 0
 	for r, as := range actionsPerReg {
 		ra[i] = &pb.RegionAction{

--- a/region/multi.go
+++ b/region/multi.go
@@ -74,6 +74,8 @@ func (m *multi) toProto(isCellblocks bool) (proto.Message, [][]byte, uint32) {
 	actionsPerReg := map[hrpc.RegionInfo]actions{}
 	var size uint32
 
+	pbActions := make([]pb.Action, len(m.calls))
+	indices := make([]uint32, len(m.calls))
 	for i, c := range m.calls {
 		if c.Context().Err() != nil {
 			// context has expired, don't bother sending it
@@ -91,9 +93,9 @@ func (m *multi) toProto(isCellblocks bool) (proto.Message, [][]byte, uint32) {
 			msg = c.ToProto()
 		}
 
-		a := &pb.Action{
-			Index: proto.Uint32(uint32(i) + 1), // +1 because 0 index means there's no index
-		}
+		a := &pbActions[i]
+		indices[i] = uint32(i) + 1 // +1 because 0 index means there's no index
+		a.Index = &indices[i]
 
 		switch r := msg.(type) {
 		case *pb.GetRequest:

--- a/region/multi.go
+++ b/region/multi.go
@@ -71,7 +71,7 @@ type actions struct {
 
 func (m *multi) toProto(isCellblocks bool, cbs [][]byte) (proto.Message, [][]byte, uint32) {
 	// aggregate calls per region
-	actionsPerReg := map[hrpc.RegionInfo]actions{}
+	actionsPerReg := map[hrpc.RegionInfo]*actions{}
 	var size uint32
 
 	pbActions := make([]pb.Action, len(m.calls))
@@ -85,7 +85,8 @@ func (m *multi) toProto(isCellblocks bool, cbs [][]byte) (proto.Message, [][]byt
 
 		as, ok := actionsPerReg[c.Region()]
 		if !ok {
-			as = actions{}
+			as = &actions{}
+			actionsPerReg[c.Region()] = as
 		}
 
 		var msg proto.Message
@@ -111,8 +112,6 @@ func (m *multi) toProto(isCellblocks bool, cbs [][]byte) (proto.Message, [][]byt
 		}
 
 		as.pbs = append(as.pbs, a)
-
-		actionsPerReg[c.Region()] = as
 	}
 
 	// construct the multi proto

--- a/region/multi_test.go
+++ b/region/multi_test.go
@@ -371,7 +371,7 @@ func TestMultiToProto(t *testing.T) {
 					t.Fatal("multi is full")
 				}
 			}
-			cellblocksProto, cellblocks, cellblocksLen := m.SerializeCellBlocks()
+			cellblocksProto, cellblocks, cellblocksLen := m.SerializeCellBlocks(nil)
 			out, ok = cellblocksProto.(*pb.MultiRequest)
 			if !ok {
 				t.Fatalf("unexpected proto type %T", cellblocksProto)
@@ -1044,13 +1044,13 @@ func BenchmarkMultiToProto(b *testing.B) {
 	b.Run("cellblocks", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			m.toProto(true)
+			m.toProto(true, nil)
 		}
 	})
 	b.Run("no_cellblocks", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			m.toProto(false)
+			m.toProto(false, nil)
 		}
 	})
 }
@@ -1102,7 +1102,7 @@ func BenchmarkMultiToProtoLarge(b *testing.B) {
 	b.Run("cellblocks", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			m.toProto(true)
+			m.toProto(true, nil)
 		}
 	})
 }


### PR DESCRIPTION
A handful of changes to optimize serialization of a multi into cellblocks with a big emphasis on reducing allocations.
The current state of the code does about one allocation per value in a call plus around 6 allocations per call. The MultiToProtoLarge benchmark creates a multi with 1000 calls, each with 5 values and would result in 11.2k allocations. 
The code in this change brings it to roughly 4 allocations per call in a multi and removes the per-value allocation, bringing the allocation count to 4.2k in MultiToProtoLarge.

The MultiToProto (not large) benchmark creates a multi with 5 calls, each with 0 or 1 value. It does not see as much benefits from these changes. The common case is sending a large multi, so I think that tradeoff is worth it.

```
name                             old time/op    new time/op    delta
MultiToProto/cellblocks-16         5.11µs ± 1%    4.94µs ± 0%   -3.39%  (p=0.000 n=10+10)
MultiToProto/no_cellblocks-16      4.67µs ± 1%    4.67µs ± 0%     ~     (p=0.589 n=9+10)
MultiToProtoLarge/cellblocks-16    1.69ms ± 1%    1.13ms ± 0%  -33.36%  (p=0.000 n=10+10)

name                             old alloc/op   new alloc/op   delta
MultiToProto/cellblocks-16         3.02kB ± 0%    2.93kB ± 0%   -3.06%  (p=0.000 n=10+10)
MultiToProto/no_cellblocks-16      3.44kB ± 0%    3.56kB ± 0%   +3.49%  (p=0.000 n=10+10)
MultiToProtoLarge/cellblocks-16    1.68MB ± 0%    0.91MB ± 0%  -45.87%  (p=0.000 n=10+10)

name                             old allocs/op  new allocs/op  delta
MultiToProto/cellblocks-16           53.0 ± 0%      43.0 ± 0%  -18.87%  (p=0.000 n=10+10)
MultiToProto/no_cellblocks-16        59.0 ± 0%      54.0 ± 0%   -8.47%  (p=0.000 n=10+10)
MultiToProtoLarge/cellblocks-16     11.2k ± 0%      4.2k ± 0%  -62.49%  (p=0.000 n=10+10)
```