### PR TITLE
region: Add batch_flush_size histogram metric

### DIFF
--- a/region/client.go
+++ b/region/client.go
@@ -346,6 +346,7 @@ func (c *client) processRPCs() {
 		flushReasonCount.With(prometheus.Labels{
 			"reason": reason,
 		}).Inc()
+		flushSize.WithLabelValues(c.Addr()).Observe(float64(m.len()))
 
 		if err := c.trySend(m); err != nil {
 			m.returnResults(nil, err)

--- a/region/prometheus.go
+++ b/region/prometheus.go
@@ -19,4 +19,14 @@ var (
 		},
 		[]string{"reason"},
 	)
+
+	flushSize = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "gohbase",
+			Name:      "batch_flush_size",
+			Help:      "Number of RPCs sent in multis",
+			Buckets:   prometheus.ExponentialBuckets(1, 5, 8),
+		},
+		[]string{"regionserver"},
+	)
 )


### PR DESCRIPTION
This will expose the size of batches being sent by gohbase.

Buckets are [1, 5, 25, 125, 625, 3125, 15625, 78125]. This should capture all expected sizes of batches and importantly count all the batches that have exactly 1 request in them. In one setup I saw 90% of batches containing exactly 1 request and in another the 99.9%tile value was ~3100 with spikes over 8000.