### PR TITLE
SendBatch: Don't start goroutines

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -10,16 +10,28 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var operationDurationSeconds = promauto.NewHistogramVec(
-	prometheus.HistogramOpts{
-		Namespace: "gohbase",
-		Name:      "operation_duration_seconds",
-		Help:      "Time in seconds for operation to complete",
-		//   >>> [0.04*(2**i) for i in range(11)]
-		//   [0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96]
-		// Meaning 40ms, 80ms, 160ms, 320ms, 640ms, 1.28s, ... max 40.96s
-		// (most requests have a 30s timeout by default at the Envoy level)
-		Buckets: prometheus.ExponentialBuckets(0.04, 2, 11),
-	},
-	[]string{"operation", "result"},
+var (
+	operationDurationSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "gohbase",
+			Name:      "operation_duration_seconds",
+			Help:      "Time in seconds for operation to complete",
+			//   >>> [0.04*(2**i) for i in range(11)]
+			//   [0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96]
+			// Meaning 40ms, 80ms, 160ms, 320ms, 640ms, 1.28s, ... max 40.96s
+			// (most requests have a 30s timeout by default at the Envoy level)
+			Buckets: prometheus.ExponentialBuckets(0.04, 2, 11),
+		},
+		[]string{"operation", "result"},
+	)
+
+	sendBatchSplitCount = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "gohbase",
+			Name:      "sendbatch_split_count",
+			Help:      "Count of Region Servers hit per SendBatch",
+			// 1, 2, 4, 8, 16, 32, 64, 128, 256, 512
+			Buckets: prometheus.ExponentialBuckets(1, 2, 10),
+		},
+	)
 )

--- a/rpc.go
+++ b/rpc.go
@@ -239,6 +239,7 @@ func (c *client) SendBatch(ctx context.Context, batch []hrpc.Call) (
 	if !ok {
 		return res, false
 	}
+	sendBatchSplitCount.Observe(float64(len(rpcByClient)))
 
 	// Send each group of RPCs to region client to be executed.
 	type clientAndRPCs struct {


### PR DESCRIPTION
Instead of starting goroutines we can queue each region server's collection of RPCs and only after queueing them all wait for all responses. We get a similar amount of parallelism, the only potential slow down is that we can't queue one region server's RPCs until the previous is able to be queued.

By not starting goroutines, the resource usage of SendBatch is more predictable. And not starting goroutines is likely to be less expensive overall.

This change also adds a new metric for number of splits that occur in SendBatch.