### PR TITLE
SendBatch: Retry retryable errors

### DIFF
--- a/rpc_test.go
+++ b/rpc_test.go
@@ -717,15 +717,6 @@ func TestConcurrentRetryableError(t *testing.T) {
 		nil,
 		nil,
 	)
-	// fake region to make sure we don't close the client
-	whateverRegion := region.NewInfo(
-		0,
-		nil,
-		[]byte("test2"),
-		[]byte("test2,,1234567890042.56f833d5569a27c7a43fbf547b4924a4."),
-		nil,
-		nil,
-	)
 
 	rc := mockRegion.NewMockRegionClient(ctrl)
 	rc.EXPECT().String().Return("mock region client").AnyTimes()
@@ -733,12 +724,11 @@ func TestConcurrentRetryableError(t *testing.T) {
 	newRC := func() hrpc.RegionClient {
 		return rc
 	}
+	c.clients.put("host:1234", c.metaRegionInfo, newRC)
+	c.metaRegionInfo.SetClient(rc)
 	c.regions.put(origlReg)
-	c.regions.put(whateverRegion)
 	c.clients.put("host:1234", origlReg, newRC)
-	c.clients.put("host:1234", whateverRegion, newRC)
 	origlReg.SetClient(rc)
-	whateverRegion.SetClient(rc)
 
 	numCalls := 100
 	rc.EXPECT().QueueRPC(gomock.Any()).MinTimes(1)


### PR DESCRIPTION
To match the behavior of SendRPC, SendBatch should retry RPCs that hit retryable errors: region.RetryableError, region.ServerError, and region.NotServingRegionError.

SendBatch will now retry each RPC that hits a retryable error. What used to be a single step through of assigning regions to RPCs, grouping them by region server and then dispatching the RPCs to their respective servers, is now done in a loop. The first iteration of the loop operates on the entire batch. Later iterations operate on the set of RPCs that failed with retryable errors in the previous batch.