### PR TITLE
hrpc/snapshot: keep version unset if not specified

### DIFF
--- a/hrpc/snapshot.go
+++ b/hrpc/snapshot.go
@@ -17,7 +17,7 @@ type snap struct {
 	name         string
 	table        string
 	snapshotType *pb.SnapshotDescription_Type
-	version      int32
+	version      *int32
 	owner        string
 }
 
@@ -26,13 +26,13 @@ func (s *snap) ToProto() *pb.SnapshotDescription {
 		Type:    s.snapshotType,
 		Table:   proto.String(s.table),
 		Name:    proto.String(s.name),
-		Version: proto.Int32(s.version),
+		Version: s.version,
 		Owner:   proto.String(s.owner),
 	}
 }
 
 func (s *snap) Version(v int32) {
-	s.version = v
+	s.version = &v
 }
 
 func (s *snap) Owner(o string) {


### PR DESCRIPTION
HBase has 2 snapshot formats: version 0 and version 2. Version 2 is more efficient as it doesn't require the creation of thousand of empty files and instead create a single manifest file[1].

The snapshot format version is dependent of the SnapshotDescription. When the version is not set, HBase will use the default version. In HBase 1.x/2.x, the default version is 2.

Unfortunately, gohbase implementation always set the version to 0, even when the caller didn't explicitly set the version. This is is because internally gohbase use an int32 (not a pointer) which default to 0 implicitly.

This change switch the internal storage to a pointer, to match the "optional" behaviour on the protobuf side.

[1] More details at:
- https://issues.apache.org/jira/browse/HBASE-7987
- https://github.com/apache/hbase/commit/a669c765f7de5b8445229c8ff9274051df7b794c