### PR TITLE
Expose Dialers inside Zk and Region

### DIFF
--- a/admin_client.go
+++ b/admin_client.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"
 	"github.com/tsuna/gohbase/region"

--- a/admin_client.go
+++ b/admin_client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"
 	"github.com/tsuna/gohbase/region"
@@ -67,7 +68,7 @@ func newAdminClient(zkquorum string, options ...Option) AdminClient {
 	for _, option := range options {
 		option(c)
 	}
-	c.zkClient = zk.NewClient(zkquorum, c.zkTimeout)
+	c.zkClient = zk.NewClient(zkquorum, c.zkTimeout, c.zkDialer)
 	return c
 }
 

--- a/client.go
+++ b/client.go
@@ -15,14 +15,14 @@ import (
 
 	gzk "github.com/go-zookeeper/zk"
 	log "github.com/sirupsen/logrus"
-	"google.golang.org/protobuf/proto"
-	"modernc.org/b/v2"
 
 	"github.com/tsuna/gohbase/compression"
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"
 	"github.com/tsuna/gohbase/region"
 	"github.com/tsuna/gohbase/zk"
+	"google.golang.org/protobuf/proto"
+	"modernc.org/b/v2"
 )
 
 const (

--- a/client.go
+++ b/client.go
@@ -98,7 +98,8 @@ type client struct {
 	closeOnce sync.Once
 
 	newRegionClientFn func(string, region.ClientType, int, time.Duration,
-		string, time.Duration, compression.Codec, func(ctx context.Context, network, addr string) (net.Conn, error)) hrpc.RegionClient
+		string, time.Duration, compression.Codec,
+		func(ctx context.Context, network, addr string) (net.Conn, error)) hrpc.RegionClient
 
 	compressionCodec compression.Codec
 
@@ -278,7 +279,8 @@ func CompressionCodec(codec string) Option {
 // ZooKeeperDialer will return an option to pass the given dialer function
 // into the ZooKeeper client Connect() call, which allows for customizing
 // network connections.
-func ZooKeeperDialer(dialer func(ctx context.Context, network, addr string) (net.Conn, error)) Option {
+func ZooKeeperDialer(dialer func(
+	ctx context.Context, network, addr string) (net.Conn, error)) Option {
 	return func(c *client) {
 		c.zkDialer = dialer
 	}
@@ -286,7 +288,8 @@ func ZooKeeperDialer(dialer func(ctx context.Context, network, addr string) (net
 
 // RegionDialer will return an option that uses the specified Dialer for
 // connecting to region servers. This allows for connecting through proxies.
-func RegionDialer(dialer func(ctx context.Context, network, addr string) (net.Conn, error)) Option {
+func RegionDialer(dialer func(
+	ctx context.Context, network, addr string) (net.Conn, error)) Option {
 	return func(c *client) {
 		c.regionDialer = dialer
 	}

--- a/debug_state_test.go
+++ b/debug_state_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/region"
 )
@@ -25,6 +26,7 @@ func TestDebugStateSanity(t *testing.T) {
 		defaultEffectiveUser,
 		region.DefaultReadTimeout,
 		client.compressionCodec,
+		nil,
 	)
 	newClientFn := func() hrpc.RegionClient {
 		return regClient

--- a/mockrc_test.go
+++ b/mockrc_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -177,7 +178,7 @@ func init() {
 
 func newMockRegionClient(addr string, ctype region.ClientType, queueSize int,
 	flushInterval time.Duration, effectiveUser string,
-	readTimeout time.Duration, codec compression.Codec, dialer region.Dialer) hrpc.RegionClient {
+	readTimeout time.Duration, codec compression.Codec, dialer func(ctx context.Context, network, addr string) (net.Conn, error)) hrpc.RegionClient {
 	m.Lock()
 	clients[addr]++
 	m.Unlock()

--- a/mockrc_test.go
+++ b/mockrc_test.go
@@ -13,11 +13,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/tsuna/gohbase/compression"
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"
 	"github.com/tsuna/gohbase/region"
-	"google.golang.org/protobuf/proto"
 )
 
 type testClient struct {
@@ -177,7 +178,7 @@ func init() {
 
 func newMockRegionClient(addr string, ctype region.ClientType, queueSize int,
 	flushInterval time.Duration, effectiveUser string,
-	readTimeout time.Duration, codec compression.Codec) hrpc.RegionClient {
+	readTimeout time.Duration, codec compression.Codec, dialer region.Dialer) hrpc.RegionClient {
 	m.Lock()
 	clients[addr]++
 	m.Unlock()

--- a/mockrc_test.go
+++ b/mockrc_test.go
@@ -13,12 +13,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/tsuna/gohbase/compression"
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"
 	"github.com/tsuna/gohbase/region"
+	"google.golang.org/protobuf/proto"
 )
 
 type testClient struct {

--- a/mockrc_test.go
+++ b/mockrc_test.go
@@ -178,7 +178,8 @@ func init() {
 
 func newMockRegionClient(addr string, ctype region.ClientType, queueSize int,
 	flushInterval time.Duration, effectiveUser string,
-	readTimeout time.Duration, codec compression.Codec, dialer func(ctx context.Context, network, addr string) (net.Conn, error)) hrpc.RegionClient {
+	readTimeout time.Duration, codec compression.Codec,
+	dialer func(ctx context.Context, network, addr string) (net.Conn, error)) hrpc.RegionClient {
 	m.Lock()
 	clients[addr]++
 	m.Unlock()

--- a/region/client.go
+++ b/region/client.go
@@ -194,7 +194,7 @@ type client struct {
 	compressor *compressor
 
 	// dialer is used to connect to region servers in non-standard ways
-	dialer Dialer
+	dialer func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
 // QueueRPC will add an rpc call to the queue for processing by the writer goroutine

--- a/region/client.go
+++ b/region/client.go
@@ -22,10 +22,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/tsuna/gohbase/hrpc"
-	"github.com/tsuna/gohbase/pb"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/tsuna/gohbase/hrpc"
+	"github.com/tsuna/gohbase/pb"
 )
 
 // ClientType is a type alias to represent the type of this region client
@@ -192,6 +193,9 @@ type client struct {
 
 	// compressor for cellblocks. if nil, then no compression
 	compressor *compressor
+
+	// dialer is used to connect to region servers in non-standard ways
+	dialer Dialer
 }
 
 // QueueRPC will add an rpc call to the queue for processing by the writer goroutine

--- a/region/client.go
+++ b/region/client.go
@@ -22,11 +22,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"google.golang.org/protobuf/encoding/protowire"
-	"google.golang.org/protobuf/proto"
-
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
 )
 
 // ClientType is a type alias to represent the type of this region client

--- a/rpc.go
+++ b/rpc.go
@@ -16,13 +16,13 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"go.opentelemetry.io/otel/codes"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/internal/observability"
 	"github.com/tsuna/gohbase/region"
 	"github.com/tsuna/gohbase/zk"
+	"go.opentelemetry.io/otel/codes"
+	"google.golang.org/protobuf/proto"
 )
 
 // Constants

--- a/rpc.go
+++ b/rpc.go
@@ -16,12 +16,13 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/codes"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/internal/observability"
 	"github.com/tsuna/gohbase/region"
 	"github.com/tsuna/gohbase/zk"
-	"go.opentelemetry.io/otel/codes"
-	"google.golang.org/protobuf/proto"
 )
 
 // Constants
@@ -828,11 +829,11 @@ func (c *client) establishRegion(reg hrpc.RegionInfo, addr string) {
 			// master that we don't add to the cache
 			// TODO: consider combining this case with the regular regionserver path
 			client = c.newRegionClientFn(addr, c.clientType, c.rpcQueueSize, c.flushInterval,
-				c.effectiveUser, c.regionReadTimeout, nil)
+				c.effectiveUser, c.regionReadTimeout, nil, c.regionDialer)
 		} else {
 			client = c.clients.put(addr, reg, func() hrpc.RegionClient {
 				return c.newRegionClientFn(addr, c.clientType, c.rpcQueueSize, c.flushInterval,
-					c.effectiveUser, c.regionReadTimeout, c.compressionCodec)
+					c.effectiveUser, c.regionReadTimeout, c.compressionCodec, c.regionDialer)
 			})
 		}
 

--- a/rpc.go
+++ b/rpc.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/internal/observability"
 	"github.com/tsuna/gohbase/region"

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -20,9 +20,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/wrapperspb"
-	"modernc.org/b/v2"
 
 	"github.com/tsuna/gohbase/compression"
 	"github.com/tsuna/gohbase/hrpc"
@@ -33,6 +30,9 @@ import (
 	mockRegion "github.com/tsuna/gohbase/test/mock/region"
 	mockZk "github.com/tsuna/gohbase/test/mock/zk"
 	"github.com/tsuna/gohbase/zk"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"modernc.org/b/v2"
 )
 
 func newRegionClientFn(addr string) func() hrpc.RegionClient {

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -302,7 +302,8 @@ func TestEstablishRegionDialFail(t *testing.T) {
 
 	newRegionClientFnCallCount := 0
 	c.newRegionClientFn = func(_ string, _ region.ClientType, _ int, _ time.Duration,
-		_ string, _ time.Duration, _ compression.Codec, _ func(ctx context.Context, network, addr string) (net.Conn, error)) hrpc.RegionClient {
+		_ string, _ time.Duration, _ compression.Codec,
+		_ func(ctx context.Context, network, addr string) (net.Conn, error)) hrpc.RegionClient {
 		var rc hrpc.RegionClient
 		if newRegionClientFnCallCount == 0 {
 			rc = rcFailDial

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -20,6 +20,10 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"modernc.org/b/v2"
+
 	"github.com/tsuna/gohbase/compression"
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"
@@ -29,15 +33,12 @@ import (
 	mockRegion "github.com/tsuna/gohbase/test/mock/region"
 	mockZk "github.com/tsuna/gohbase/test/mock/zk"
 	"github.com/tsuna/gohbase/zk"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/wrapperspb"
-	"modernc.org/b/v2"
 )
 
 func newRegionClientFn(addr string) func() hrpc.RegionClient {
 	return func() hrpc.RegionClient {
 		return newMockRegionClient(addr, region.RegionClient,
-			0, 0, "root", region.DefaultReadTimeout, nil)
+			0, 0, "root", region.DefaultReadTimeout, nil, nil)
 	}
 }
 
@@ -301,7 +302,7 @@ func TestEstablishRegionDialFail(t *testing.T) {
 
 	newRegionClientFnCallCount := 0
 	c.newRegionClientFn = func(_ string, _ region.ClientType, _ int, _ time.Duration,
-		_ string, _ time.Duration, _ compression.Codec) hrpc.RegionClient {
+		_ string, _ time.Duration, _ compression.Codec, _ region.Dialer) hrpc.RegionClient {
 		var rc hrpc.RegionClient
 		if newRegionClientFnCallCount == 0 {
 			rc = rcFailDial

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
 	"reflect"
 	"strconv"
 	"strings"
@@ -20,7 +21,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/tsuna/gohbase/compression"
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"
@@ -302,7 +302,7 @@ func TestEstablishRegionDialFail(t *testing.T) {
 
 	newRegionClientFnCallCount := 0
 	c.newRegionClientFn = func(_ string, _ region.ClientType, _ int, _ time.Duration,
-		_ string, _ time.Duration, _ compression.Codec, _ region.Dialer) hrpc.RegionClient {
+		_ string, _ time.Duration, _ compression.Codec, _ func(ctx context.Context, network, addr string) (net.Conn, error)) hrpc.RegionClient {
 		var rc hrpc.RegionClient
 		if newRegionClientFnCallCount == 0 {
 			rc = rcFailDial

--- a/zk/client.go
+++ b/zk/client.go
@@ -63,7 +63,8 @@ type client struct {
 }
 
 // NewClient establishes connection to zookeeper and returns the client
-func NewClient(zkquorum string, st time.Duration, dialer func(ctx context.Context, network, addr string) (net.Conn, error)) Client {
+func NewClient(zkquorum string, st time.Duration,
+	dialer func(ctx context.Context, network, addr string) (net.Conn, error)) Client {
 	return &client{
 		zks:            strings.Split(zkquorum, ","),
 		sessionTimeout: st,
@@ -126,7 +127,8 @@ func (c *client) LocateResource(resource ResourceName) (string, error) {
 	return net.JoinHostPort(*server.HostName, fmt.Sprint(*server.Port)), nil
 }
 
-func makeZKDialer(ctxDialer func(ctx context.Context, network, addr string) (net.Conn, error)) zk.Dialer {
+func makeZKDialer(ctxDialer func(
+	ctx context.Context, network, addr string) (net.Conn, error)) zk.Dialer {
 	return func(network, addr string, timeout time.Duration) (net.Conn, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()

--- a/zk/client.go
+++ b/zk/client.go
@@ -17,9 +17,8 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/go-zookeeper/zk"
-	"google.golang.org/protobuf/proto"
-
 	"github.com/tsuna/gohbase/pb"
+	"google.golang.org/protobuf/proto"
 )
 
 type logger struct{}


### PR DESCRIPTION
Fixes #248

This change allows for overriding the default dialers used by the ZooKeeper client and the Region client to connect to their respective servers. Proxy-aware dialers can be installed by people who need them.