### PR TITLE
cache: added region cache warmup

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,6 +43,7 @@ type Client interface {
 	CheckAndPut(p *hrpc.Mutate, family string, qualifier string,
 		expectedValue []byte) (bool, error)
 	SendBatch(ctx context.Context, batch []hrpc.Call) (res []hrpc.RPCResult, allOK bool)
+	CacheRegions(table []byte) error
 	Close()
 }
 
@@ -390,4 +391,11 @@ func (c *client) CheckAndPut(p *hrpc.Mutate, family string,
 	}
 
 	return r.GetProcessed(), nil
+}
+
+// CacheRegions scan the meta region to get all the regions and populate to cache.
+// This can be used to warm up region cache
+func (c *client) CacheRegions(table []byte) error {
+	_, err := c.findAllRegions(context.Background(), table)
+	return err
 }

--- a/region/info.go
+++ b/region/info.go
@@ -384,7 +384,7 @@ func (i *info) MarshalJSON() ([]byte, error) {
 		StopKey:         string(i.stopKey),
 		ContextInstance: fmt.Sprintf("%p", (i.ctx)),
 		Err:             ctxError,
-		Client:          fmt.Sprintf("%p", (i.client)),
+		Client:          fmt.Sprintf("%p", (i.Client())),
 		Available:       !i.IsUnavailable(),
 	}
 	jsonVal, err := json.Marshal(state)

--- a/region/new.go
+++ b/region/new.go
@@ -50,12 +50,15 @@ func NewClient(addr string, ctype ClientType, queueSize int, flushInterval time.
 
 func (c *client) Dial(ctx context.Context) error {
 	c.dialOnce.Do(func() {
-		var err error
-		c.conn, err = c.dialer(ctx, "tcp", c.addr)
+		conn, err := c.dialer(ctx, "tcp", c.addr)
 		if err != nil {
 			c.fail(fmt.Errorf("failed to dial RegionServer: %s", err))
 			return
 		}
+
+		c.connM.Lock()
+		c.conn = conn
+		c.connM.Unlock()
 
 		// time out send hello if it take long
 		if deadline, ok := ctx.Deadline(); ok {

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -702,6 +702,20 @@ func TestMetaLookupCanceledContext(t *testing.T) {
 	}
 }
 
+func TestMetaLookupAllRegionsCanceledContext(t *testing.T) {
+	c := newMockClient(nil)
+	// pretend regionserver:0 has meta table
+	rc := c.clients.put("regionserver:0", c.metaRegionInfo, newRegionClientFn("regionserver:0"))
+	c.metaRegionInfo.SetClient(rc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := c.metaLookupForTable(ctx, []byte("tablenotfound"))
+	if err != context.Canceled {
+		t.Errorf("Expected error %v, got error %v", context.Canceled, err)
+	}
+}
+
 func TestConcurrentRetryableError(t *testing.T) {
 	ctrl := test.NewController(t)
 	defer ctrl.Finish()

--- a/test/mock/client.go
+++ b/test/mock/client.go
@@ -50,6 +50,20 @@ func (mr *MockClientMockRecorder) Append(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Append", reflect.TypeOf((*MockClient)(nil).Append), arg0)
 }
 
+// CacheRegions mocks base method.
+func (m *MockClient) CacheRegions(arg0 []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CacheRegions", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CacheRegions indicates an expected call of CacheRegions.
+func (mr *MockClientMockRecorder) CacheRegions(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheRegions", reflect.TypeOf((*MockClient)(nil).CacheRegions), arg0)
+}
+
 // CheckAndPut mocks base method.
 func (m *MockClient) CheckAndPut(arg0 *hrpc.Mutate, arg1, arg2 string, arg3 []byte) (bool, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This change adds an option in gohbase to prepopulate its region cache. It does a single scan of the meta table and cache all regions.