### PR TITLE
Replace logrus with log/slog for logging

### DIFF
--- a/admin_client.go
+++ b/admin_client.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/pb"
 	"github.com/tsuna/gohbase/region"
@@ -48,9 +48,6 @@ func NewAdminClient(zkquorum string, options ...Option) AdminClient {
 }
 
 func newAdminClient(zkquorum string, options ...Option) AdminClient {
-	log.WithFields(log.Fields{
-		"Host": zkquorum,
-	}).Debug("Creating new admin client.")
 	c := &client{
 		clientType:    region.MasterClient,
 		rpcQueueSize:  defaultRPCQueueSize,
@@ -63,11 +60,13 @@ func newAdminClient(zkquorum string, options ...Option) AdminClient {
 		regionLookupTimeout: region.DefaultLookupTimeout,
 		regionReadTimeout:   region.DefaultReadTimeout,
 		newRegionClientFn:   region.NewClient,
+		logger:              slog.Default(),
 	}
 	for _, option := range options {
 		option(c)
 	}
-	c.zkClient = zk.NewClient(zkquorum, c.zkTimeout, c.zkDialer)
+	c.logger.Debug("Creating new admin client.", "Host", slog.StringValue(zkquorum))
+	c.zkClient = zk.NewClient(zkquorum, c.zkTimeout, c.zkDialer, c.logger)
 	return c
 }
 

--- a/debug_state_test.go
+++ b/debug_state_test.go
@@ -2,6 +2,7 @@ package gohbase
 
 import (
 	"encoding/json"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,6 +28,7 @@ func TestDebugStateSanity(t *testing.T) {
 		region.DefaultReadTimeout,
 		client.compressionCodec,
 		nil,
+		slog.Default(),
 	)
 	newClientFn := func() hrpc.RegionClient {
 		return regClient

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-zookeeper/zk v1.0.3
 	github.com/golang/snappy v0.0.4
 	github.com/prometheus/client_golang v1.19.1
-	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/otel v1.27.0
 	go.opentelemetry.io/otel/trace v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,6 @@ github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6O
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/integration_test.go
+++ b/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"math"
 	"os"
 	"os/exec"
@@ -26,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/tsuna/gohbase"
 	"github.com/tsuna/gohbase/filter"
@@ -100,7 +100,7 @@ func TestMain(m *testing.M) {
 		panic("Host is not set!")
 	}
 
-	log.SetLevel(log.DebugLevel)
+	slog.SetLogLoggerLevel(slog.LevelDebug)
 
 	ac := gohbase.NewAdminClient(*host)
 

--- a/mockrc_test.go
+++ b/mockrc_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -179,7 +180,8 @@ func init() {
 func newMockRegionClient(addr string, ctype region.ClientType, queueSize int,
 	flushInterval time.Duration, effectiveUser string,
 	readTimeout time.Duration, codec compression.Codec,
-	dialer func(ctx context.Context, network, addr string) (net.Conn, error)) hrpc.RegionClient {
+	dialer func(ctx context.Context, network, addr string) (net.Conn, error),
+	log *slog.Logger) hrpc.RegionClient {
 	m.Lock()
 	clients[addr]++
 	m.Unlock()

--- a/region/new.go
+++ b/region/new.go
@@ -11,6 +11,7 @@ package region
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"time"
 
@@ -21,7 +22,8 @@ import (
 // NewClient creates a new RegionClient.
 func NewClient(addr string, ctype ClientType, queueSize int, flushInterval time.Duration,
 	effectiveUser string, readTimeout time.Duration, codec compression.Codec,
-	dialer func(ctx context.Context, network, addr string) (net.Conn, error)) hrpc.RegionClient {
+	dialer func(ctx context.Context, network, addr string) (net.Conn, error),
+	slogger *slog.Logger) hrpc.RegionClient {
 	c := &client{
 		addr:          addr,
 		ctype:         ctype,
@@ -32,6 +34,7 @@ func NewClient(addr string, ctype ClientType, queueSize int, flushInterval time.
 		rpcs:          make(chan []hrpc.Call),
 		done:          make(chan struct{}),
 		sent:          make(map[uint32]hrpc.Call),
+		logger:        slogger,
 	}
 
 	if codec != nil {


### PR DESCRIPTION
Fixes: #247 
We are using log/slog instead of logrus, and replace logrus fatal log level (which doesn't exist in slog) with panic 