### PR TITLE
region: Simplify buffer funcs

### DIFF
--- a/region/client.go
+++ b/region/client.go
@@ -108,10 +108,7 @@ func newBuffer(size int) []byte {
 	if v != nil {
 		b = v.([]byte)
 	}
-	if cap(b) < size {
-		return append(b[:0], make([]byte, size)...)[:size]
-	}
-	return b[:size]
+	return append(b[:0], make([]byte, size)...)
 }
 
 func freeBuffer(b []byte) {

--- a/region/compressor_test.go
+++ b/region/compressor_test.go
@@ -170,13 +170,13 @@ func benchmarkDecompressCellblocks(b *testing.B, blockLen int, blocksCount int) 
 	b.ReportAllocs()
 
 	data := make([]byte, blockLen)
-	rand.Seed(int64(b.N))
+	r := rand.New(rand.NewSource(42))
 
 	c := &compressor{Codec: mockCodec{}}
 
 	var compressedCellblocks []byte
 	for i := 0; i < blocksCount; i++ {
-		_, err := rand.Read(data)
+		_, err := r.Read(data)
 		if err != nil {
 			b.FailNow()
 		}


### PR DESCRIPTION
Replace `growBuffer` with `append` and `resizeBufferCap` with `slices.Grow`. And remove redundant `if` checks on capacity or size that `append` will do as well. This is equivalent behavior after undoing the unintentional change from commit https://github.com/tsuna/gohbase/commit/1fee39f343954ca7501a6b8f25abd9f86eaf618b. Benchmarks show the performance is equivalent to the code before commit https://github.com/tsuna/gohbase/commit/1fee39f343954ca7501a6b8f25abd9f86eaf618b.

Also replace some deprecated calls to rand funcs.