### PR TITLE
gohbase: Add table and key attributes to span

### DIFF
--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -27,8 +27,7 @@ func StartSpan(
 	name string,
 	opts ...trace.SpanStartOption,
 ) (context.Context, trace.Span) {
-	tracer := otel.GetTracerProvider().Tracer("gohbase")
-	return tracer.Start(ctx, name, opts...)
+	return otel.Tracer("gohbase").Start(ctx, name, opts...)
 }
 
 // ObserveWithTrace observes the value, providing the traceID as


### PR DESCRIPTION
Improve the observability of RPC spans by including the table and key. The values are quoted to improve readability of table and key values that combine printable unicode characters with non-printable raw binary. For example, "\xc4x03Qux".