### PR TITLE
scanner: don't send scanner close request when region was exhausted

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -240,7 +240,7 @@ func (s *scanner) update(resp *pb.ScanResponse, region hrpc.RegionInfo) {
 	}
 	if !resp.GetMoreResultsInRegion() {
 		// we are done with this region, prepare scan for next region
-		s.closeRegionScanner()
+		s.curRegionScannerID = noScannerID
 
 		// Normal Scan
 		if !s.rpc.Reversed() {


### PR DESCRIPTION
HBase server already close the region scanner[1] when there is no more results to be send from that region. Therefore, it is useless to send one more request to close the scanner.

[1] https://github.com/apache/hbase/blob/rel/2.5.8/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java#L3698-L3701