### PR TITLE
hrpc, region: Allow setting priority on Scan and Get requests

### DIFF
--- a/hrpc/call.go
+++ b/hrpc/call.go
@@ -101,6 +101,7 @@ type hasQueryOptions interface {
 	setResultOffset(offset uint32)
 	setCacheBlocks(cacheBlocks bool)
 	setConsistency(consistency ConsistencyType)
+	setPriority(priority uint32)
 }
 
 // RPCResult is struct that will contain both the resulting message from an RPC

--- a/hrpc/query.go
+++ b/hrpc/query.go
@@ -23,6 +23,7 @@ type baseQuery struct {
 	maxVersions   uint32
 	storeLimit    uint32
 	storeOffset   uint32
+	priority      uint32
 	cacheBlocks   bool
 	consistency   ConsistencyType
 }
@@ -96,6 +97,15 @@ func (bq *baseQuery) setCacheBlocks(cacheBlocks bool) {
 }
 func (bq *baseQuery) setConsistency(consistency ConsistencyType) {
 	bq.consistency = consistency
+}
+func (bq *baseQuery) setPriority(priority uint32) {
+	bq.priority = priority
+}
+func (bq *baseQuery) Priority() *uint32 {
+	if bq.priority == 0 {
+		return nil
+	}
+	return &bq.priority
 }
 
 // Families option adds families constraint to a Scan or Get request.
@@ -216,5 +226,15 @@ func Consistency(consistency ConsistencyType) func(Call) error {
 			return nil
 		}
 		return errors.New("'Consistency' option can only be used with Get or Scan requests")
+	}
+}
+
+func Priority(priority uint32) func(Call) error {
+	return func(hc Call) error {
+		if c, ok := hc.(hasQueryOptions); ok {
+			c.setPriority(priority)
+			return nil
+		}
+		return errors.New("'Priority' option can only be used with Get or Scan requests")
 	}
 }

--- a/hrpc/query_test.go
+++ b/hrpc/query_test.go
@@ -208,3 +208,49 @@ func TestCacheBlocks(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestPriority(t *testing.T) {
+	get, err := NewGet(nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := get.Priority(); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+	get, err = NewGet(nil, nil, nil, Priority(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := get.Priority(); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+	get, err = NewGet(nil, nil, nil, Priority(5))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := get.Priority(); *got != 5 {
+		t.Errorf("expected priority 5, got %v", got)
+	}
+
+	scan, err := NewScan(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := scan.Priority(); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+	scan, err = NewScan(nil, nil, Priority(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := scan.Priority(); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+	scan, err = NewScan(nil, nil, Priority(5))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := scan.Priority(); *got != 5 {
+		t.Errorf("expected priority 5, got %v", got)
+	}
+}

--- a/region/client.go
+++ b/region/client.go
@@ -683,10 +683,13 @@ var pbTrue = proto.Bool(true)
 func marshalProto(rpc hrpc.Call, callID uint32, request proto.Message,
 	cellblocksLen uint32) ([]byte, error) {
 	header := getHeader()
+	defer returnHeader(header)
 	header.MethodName = proto.String(rpc.Name())
 	header.RequestParam = pbTrue
 	header.CallId = &callID
-	defer returnHeader(header)
+	if p, ok := rpc.(interface{ Priority() *uint32 }); ok {
+		header.Priority = p.Priority()
+	}
 
 	if cellblocksLen > 0 {
 		header.CellBlockMeta = &pb.CellBlockMeta{


### PR DESCRIPTION
Provide an option for setting the priority on a Scan or Get request. The priority is set on the RequestHeader, so must be set by the region code when serializing the request.