### PR TITLE
Keep priority on scanner's subsequent scans

### DIFF
--- a/hrpc/query.go
+++ b/hrpc/query.go
@@ -101,11 +101,8 @@ func (bq *baseQuery) setConsistency(consistency ConsistencyType) {
 func (bq *baseQuery) setPriority(priority uint32) {
 	bq.priority = priority
 }
-func (bq *baseQuery) Priority() *uint32 {
-	if bq.priority == 0 {
-		return nil
-	}
-	return &bq.priority
+func (bq *baseQuery) Priority() uint32 {
+	return bq.priority
 }
 
 // Families option adds families constraint to a Scan or Get request.

--- a/hrpc/query_test.go
+++ b/hrpc/query_test.go
@@ -214,43 +214,34 @@ func TestPriority(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := get.Priority(); got != nil {
-		t.Errorf("expected nil, got %v", got)
-	}
-	get, err = NewGet(nil, nil, nil, Priority(0))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := get.Priority(); got != nil {
-		t.Errorf("expected nil, got %v", got)
+	if got := get.Priority(); got != 0 {
+		t.Errorf("expected 0, got %d", got)
 	}
 	get, err = NewGet(nil, nil, nil, Priority(5))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := get.Priority(); *got != 5 {
-		t.Errorf("expected priority 5, got %v", got)
+	if got := get.Priority(); got != 5 {
+		t.Errorf("expected priority 5, got %d", got)
 	}
 
 	scan, err := NewScan(nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := scan.Priority(); got != nil {
-		t.Errorf("expected nil, got %v", got)
-	}
-	scan, err = NewScan(nil, nil, Priority(0))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := scan.Priority(); got != nil {
-		t.Errorf("expected nil, got %v", got)
+	if got := scan.Priority(); got != 0 {
+		t.Errorf("expected 0, got %d", got)
 	}
 	scan, err = NewScan(nil, nil, Priority(5))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := scan.Priority(); *got != 5 {
-		t.Errorf("expected priority 5, got %v", got)
+	if got := scan.Priority(); got != 5 {
+		t.Errorf("expected priority 5, got %d", got)
+	}
+
+	_, err = NewPut(nil, nil, nil, nil, Priority(5))
+	if err == nil {
+		t.Errorf("expected error when creating Put with Priority, but got none")
 	}
 }

--- a/region/client.go
+++ b/region/client.go
@@ -687,8 +687,10 @@ func marshalProto(rpc hrpc.Call, callID uint32, request proto.Message,
 	header.MethodName = proto.String(rpc.Name())
 	header.RequestParam = pbTrue
 	header.CallId = &callID
-	if p, ok := rpc.(interface{ Priority() *uint32 }); ok {
-		header.Priority = p.Priority()
+	if p, ok := rpc.(interface{ Priority() uint32 }); ok {
+		if p := p.Priority(); p > 0 {
+			header.Priority = &p
+		}
 	}
 
 	if cellblocksLen > 0 {

--- a/scanner.go
+++ b/scanner.go
@@ -216,7 +216,9 @@ func (s *scanner) request() (*pb.ScanResponse, hrpc.RegionInfo, error) {
 			s.startRow,
 			nil,
 			hrpc.ScannerID(s.curRegionScannerID),
-			hrpc.NumberOfRows(s.rpc.NumberOfRows()))
+			hrpc.NumberOfRows(s.rpc.NumberOfRows()),
+			hrpc.Priority(s.rpc.Priority()),
+		)
 	}
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
If a scanner needs to scan multiple times ensure all scanners get the priority set in the initial hrpc.Scan.

Updated baseQuery.Priority to return a uint32 rather than a *uint32 to be less weird.
