### PR TITLE
AdminClient: set snapshot table and apply snapshot to new table

### DIFF
--- a/admin_client.go
+++ b/admin_client.go
@@ -24,7 +24,7 @@ const (
 	snaphotValidateInterval time.Duration = time.Second / 2
 )
 
-// AdminClient to perform admistrative operations with HMaster
+// AdminClient to perform administrative operations with HMaster
 type AdminClient interface {
 	CreateTable(t *hrpc.CreateTable) error
 	DeleteTable(t *hrpc.DeleteTable) error

--- a/hrpc/query_test.go
+++ b/hrpc/query_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/tsuna/gohbase/test"
 )
 
-func TestFamilesOption(t *testing.T) {
+func TestFamiliesOption(t *testing.T) {
 	f := map[string][]string{"yolo": []string{"swag", "meow"}}
 
 	g, err := NewGet(context.Background(), nil, nil, Families(f))

--- a/hrpc/snapshot.go
+++ b/hrpc/snapshot.go
@@ -219,7 +219,7 @@ type RestoreSnapshot struct {
 	*Snapshot
 }
 
-// NewRestoreSnapshot creates a new RestoreSnapshot request that will delete
+// NewRestoreSnapshot creates a new RestoreSnapshot request that will restore
 // the given snapshot.
 func NewRestoreSnapshot(t *Snapshot) *RestoreSnapshot {
 	return &RestoreSnapshot{t}


### PR DESCRIPTION
Add method to change the table of the hrpc.Snapshot. By setting the snapshot to a new table name that doesn't already exist, the data in the snapshot can be cloned into this new table instead of being restored to the table the snapshot was created from.