### PR TITLE
Don't restart scanner renewer on every Next call

### DIFF
--- a/client.go
+++ b/client.go
@@ -327,7 +327,7 @@ func (c *client) Close() {
 }
 
 func (c *client) Scan(s *hrpc.Scan) hrpc.Scanner {
-	return newScanner(c, s)
+	return newScanner(c, s, c.logger)
 }
 
 func (c *client) Get(g *hrpc.Get) (*hrpc.Result, error) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -2681,16 +2681,17 @@ func TestScannerTimeout(t *testing.T) {
 	}
 
 	// force lease timeout
-	time.Sleep(scannerLease)
+	time.Sleep(scannerLease * 2)
 
 	_, err = scanner.Next()
 
 	// lease timeout should return an UnknownScannerException
 	if err != nil && strings.Contains(err.Error(),
 		"org.apache.hadoop.hbase.UnknownScannerException") {
-		fmt.Println("Error matches: UnknownScannerException")
+		t.Log("Error matches: UnknownScannerException")
 	} else {
-		t.Fatalf("Error does not match org.apache.hadoop.hbase.UnknownScannerException")
+		t.Fatalf("Error does not match org.apache.hadoop.hbase.UnknownScannerException, "+
+			"got: %v", err)
 	}
 }
 
@@ -2730,8 +2731,6 @@ func TestScannerRenewal(t *testing.T) {
 	defer scanner.Close()
 	for i := 0; i < numRows; i++ {
 		rsp, err := scanner.Next()
-		// Sleep to trigger renewal
-		time.Sleep(scannerLease)
 		if err != nil {
 			t.Fatalf("Scanner.Next() returned error: %v", err)
 		}
@@ -2742,6 +2741,8 @@ func TestScannerRenewal(t *testing.T) {
 		if !bytes.Equal(rsp.Cells[0].Value, expectedValue) {
 			t.Fatalf("Unexpected value. Got %v, want %v", rsp.Cells[0].Value, expectedValue)
 		}
+		// Sleep to trigger renewal
+		time.Sleep(scannerLease * 2)
 	}
 	// Ensure scanner is exhausted
 	rsp, err := scanner.Next()

--- a/prometheus.go
+++ b/prometheus.go
@@ -53,4 +53,12 @@ var (
 			4.096, 8.192, 13.192, 18.192, 23.192, 28.192, 33.192,
 		},
 	})
+
+	scanRenewers = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "gohbase",
+		Subsystem: "scanner",
+		Name:      "renewer_count",
+		Help: "Number of active scanner renewers. " +
+			"A continually increasing value indicates an Scanner leak.",
+	})
 )

--- a/scanner.go
+++ b/scanner.go
@@ -401,8 +401,12 @@ func (s *scanner) renew(ctx context.Context, startRow []byte) error {
 }
 
 func (s *scanner) renewLoop(ctx context.Context, startRow []byte) {
+	scanRenewers.Inc()
 	t := time.NewTicker(s.rpc.RenewInterval())
-	defer t.Stop()
+	defer func() {
+		t.Stop()
+		scanRenewers.Dec()
+	}()
 
 	for {
 		select {

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"reflect"
 	"sync"
 	"testing"
@@ -120,7 +121,7 @@ func TestScanner(t *testing.T) {
 	}
 
 	var scannerID uint64 = 42
-	scanner := newScanner(c, scan)
+	scanner := newScanner(c, scan, slog.Default())
 
 	s, err := hrpc.NewScanRange(scan.Context(), table, nil, nil,
 		hrpc.NumberOfRows(2))
@@ -412,7 +413,7 @@ func TestScanMetrics(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			sc := newScanner(c, scan)
+			sc := newScanner(c, scan, slog.Default())
 
 			c.EXPECT().SendRPC(&scanMatcher{scan: scan}).Return(&pb.ScanResponse{
 				Results:     tcase.results,
@@ -488,7 +489,7 @@ func TestErrorFirstFetchNoMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	scanner := newScanner(c, scan)
+	scanner := newScanner(c, scan, slog.Default())
 
 	srange, err := hrpc.NewScanRange(context.Background(), table, nil, nil)
 	if err != nil {
@@ -528,7 +529,7 @@ func TestErrorFirstFetchWithMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	scanner := newScanner(c, scan)
+	scanner := newScanner(c, scan, slog.Default())
 
 	srange, err := hrpc.NewScanRange(context.Background(), table, nil, nil,
 		hrpc.TrackScanMetrics())
@@ -570,7 +571,7 @@ func testErrorScanFromID(t *testing.T, scan *hrpc.Scan, out []*hrpc.Result) {
 	defer wg.Wait()
 
 	var scannerID uint64 = 42
-	scanner := newScanner(c, scan)
+	scanner := newScanner(c, scan, slog.Default())
 
 	srange, err := hrpc.NewScanRange(scan.Context(), table, nil, nil, scan.Options()...)
 	if err != nil {
@@ -679,7 +680,7 @@ func testPartialResults(t *testing.T, scan *hrpc.Scan, expected []*hrpc.Result) 
 	}
 
 	var scannerID uint64
-	scanner := newScanner(c, scan)
+	scanner := newScanner(c, scan, slog.Default())
 	ctx := scan.Context()
 	for _, partial := range tcase {
 		partial := partial
@@ -736,7 +737,7 @@ func TestReversedScanner(t *testing.T) {
 
 	var scannerID uint64 = 42
 
-	scanner := newScanner(c, scan)
+	scanner := newScanner(c, scan, slog.Default())
 	ctx = scan.Context()
 	s, err := hrpc.NewScanRange(ctx, table, nil, nil, hrpc.Reversed())
 	if err != nil {
@@ -819,7 +820,7 @@ func TestScannerWithContextCanceled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	scanner := newScanner(c, scan)
+	scanner := newScanner(c, scan, slog.Default())
 
 	cancel()
 
@@ -839,7 +840,7 @@ func TestScannerClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	scanner := newScanner(c, scan)
+	scanner := newScanner(c, scan, slog.Default())
 	scanner.Close()
 
 	_, err = scanner.Next()


### PR DESCRIPTION
Most calls to Next are just reading some buffered results. The scanner renewer only needs to be stopped and started again when we ask for more results from HBase. Also, we shouldn't start a renewer if we know we have already fetched the final results.