### PR TITLE
Root: Remove Old Build Tags

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -4,7 +4,6 @@
 // that can be found in the COPYING file.
 
 //go:build integration
-// +build integration
 
 package gohbase_test
 

--- a/region/new.go
+++ b/region/new.go
@@ -4,7 +4,6 @@
 // that can be found in the COPYING file.
 
 //go:build !testing
-// +build !testing
 
 package region
 

--- a/table_test.go
+++ b/table_test.go
@@ -4,7 +4,6 @@
 // that can be found in the COPYING file.
 
 //go:build integration
-// +build integration
 
 package gohbase_test
 


### PR DESCRIPTION
Old-style build tags no longer needed. They can be removed. Sorry, they were bugging me.