### PR TITLE
Extend operation_duration_seconds buckets lower

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -16,11 +16,8 @@ var (
 			Namespace: "gohbase",
 			Name:      "operation_duration_seconds",
 			Help:      "Time in seconds for operation to complete",
-			//   >>> [0.04*(2**i) for i in range(11)]
-			//   [0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96]
-			// Meaning 40ms, 80ms, 160ms, 320ms, 640ms, 1.28s, ... max 40.96s
-			// (most requests have a 30s timeout by default at the Envoy level)
-			Buckets: prometheus.ExponentialBuckets(0.04, 2, 11),
+			// 1.25ms, 2.5ms, 5ms, 10ms, 20ms, 40ms, ..., 1.28s, ... 20.48s, 40.96s
+			Buckets: prometheus.ExponentialBuckets(0.00125, 2, 16),
 		},
 		[]string{"operation", "result"},
 	)


### PR DESCRIPTION
Add buckets starting at 1.25ms for operation_duration_seconds histogram metric.

A minimum bucker for operation_duration_seconds of 40ms is too high. A quick test on one of our clusters show most operations complete in less than 5ms.