### PR TITLE
Add ResponseSize to ScanStats

### DIFF
--- a/hrpc/scan.go
+++ b/hrpc/scan.go
@@ -85,6 +85,11 @@ type Scan struct {
 
 	scanStatsHandler ScanStatsHandler
 	scanStatsID      int64
+
+	// ResponseSize contains the size of the response after the RPC is
+	// completed. It is the size of the uncompressed cellblocks in the
+	// response. This is only meant for use internal to gohbase.
+	ResponseSize int
 }
 
 type ScanStats struct {
@@ -97,11 +102,12 @@ type ScanStats struct {
 	ScanStatsID  int64
 	// ScanMetrics are only collected if the client requests to track the scan metrics, when
 	// TrackScanMetrics() is enabled.
-	ScanMetrics map[string]int64
-	Start       time.Time
-	End         time.Time
-	Error       bool // if the scan returned error
-	Retryable   bool // if the scan returned an error and it is retryable
+	ScanMetrics  map[string]int64
+	Start        time.Time
+	End          time.Time
+	ResponseSize int
+	Error        bool // if the scan returned error
+	Retryable    bool // if the scan returned an error and it is retryable
 }
 
 type ScanStatsHandler func(*ScanStats)
@@ -331,6 +337,7 @@ func (s *Scan) DeserializeCellBlocks(m proto.Message, b []byte) (uint32, error) 
 		}
 		readLen += l
 	}
+	s.ResponseSize = int(readLen)
 	return readLen, nil
 }
 

--- a/rpc.go
+++ b/rpc.go
@@ -186,6 +186,7 @@ func (c *client) scanRpcScanStats(scan *hrpc.Scan, resp proto.Message, err error
 			stats.Error = true
 		}
 		stats.Retryable = retry
+		stats.ResponseSize = scan.ResponseSize
 		scan.ScanStatsHandler()(stats)
 	}
 }

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"log/slog"
 	"math/rand"
 	"net"
@@ -20,6 +19,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tsuna/gohbase/compression"
@@ -1928,6 +1929,8 @@ func TestSendRPCStatsHandler(t *testing.T) {
 				t.Fatalf("Failed to create scan req: %v", err)
 			}
 			expectedScanStatsID := scan.ScanStatsID()
+			scan.ResponseSize = 42
+			expectedResponseSize := scan.ResponseSize
 
 			go func() {
 				res := hrpc.RPCResult{
@@ -1965,7 +1968,8 @@ func TestSendRPCStatsHandler(t *testing.T) {
 				ss.RegionID != expectedRegionID ||
 				ss.RegionServer != addr ||
 				ss.ScannerID != noScannerID ||
-				ss.ScanStatsID != expectedScanStatsID {
+				ss.ScanStatsID != expectedScanStatsID ||
+				ss.ResponseSize != expectedResponseSize {
 				t.Fatalf("ScanStats not updated as expected, got: %v", ss)
 			}
 		})


### PR DESCRIPTION
Add ResponseSize to ScanStats. To get this value to the ScanStats the cellblocks size is stored on the *hrpc.Scan during DeserializeCellBlocks.