### PR TITLE
hrpc: Add CheckAndMutate

### DIFF
--- a/hrpc/checkandmutate.go
+++ b/hrpc/checkandmutate.go
@@ -6,6 +6,8 @@
 package hrpc
 
 import (
+	"fmt"
+
 	"github.com/tsuna/gohbase/filter"
 	"github.com/tsuna/gohbase/pb"
 	"google.golang.org/protobuf/proto"
@@ -28,6 +30,18 @@ type CheckAndMutate struct {
 // and if the compare is, perform the provided mutate request on the row
 func NewCheckAndMutate(mutate *Mutate, family string,
 	qualifier string, expectedValue []byte, compareType pb.CompareType) (*CheckAndMutate, error) {
+
+	if mutate == nil {
+		return nil, fmt.Errorf("mutate cannot be nil")
+	}
+
+	if family == "" {
+		return nil, fmt.Errorf("family cannot be empty")
+	}
+
+	if qualifier == "" {
+		return nil, fmt.Errorf("qualifier cannot be empty")
+	}
 
 	// The condition that needs to match for the edit to be applied.
 	exp := filter.NewByteArrayComparable(expectedValue)

--- a/hrpc/checkandmutate.go
+++ b/hrpc/checkandmutate.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2016  The GoHBase Authors.  All rights reserved.
+// This file is part of GoHBase.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+package hrpc
+
+import (
+	"github.com/tsuna/gohbase/filter"
+	"github.com/tsuna/gohbase/pb"
+	"google.golang.org/protobuf/proto"
+)
+
+// CheckAndMutate performs a provided Mutate operation if the value specified
+// by condition equals to the one set in the HBase.
+type CheckAndMutate struct {
+	*Mutate
+
+	family    []byte
+	qualifier []byte
+
+	compareType *pb.CompareType
+	comparator  *pb.Comparator
+}
+
+// NewCheckAndMutate creates a new CheckAndMutate request that will compare provided
+// expectedValue with the on in HBase located at mutate's row and provided family:qualifier,
+// and if the compare is, perform the provided mutate request on the row
+func NewCheckAndMutate(mutate *Mutate, family string,
+	qualifier string, expectedValue []byte, compareType pb.CompareType) (*CheckAndMutate, error) {
+
+	// The condition that needs to match for the edit to be applied.
+	exp := filter.NewByteArrayComparable(expectedValue)
+	cmp, err := filter.NewBinaryComparator(exp).ConstructPBComparator()
+	if err != nil {
+		return nil, err
+	}
+
+	// CheckAndMutate is not batchable as MultiResponse doesn't return Processed field
+	// for Mutate Action
+	mutate.setSkipBatch(true)
+
+	return &CheckAndMutate{
+		Mutate:      mutate,
+		family:      []byte(family),
+		qualifier:   []byte(qualifier),
+		compareType: &compareType,
+		comparator:  cmp,
+	}, nil
+}
+
+// ToProto converts the RPC into a protobuf message
+func (cp *CheckAndMutate) ToProto() proto.Message {
+	mutateRequest, _, _ := cp.toProto(false, nil)
+	mutateRequest.Condition = &pb.Condition{
+		Row:         cp.key,
+		Family:      cp.family,
+		Qualifier:   cp.qualifier,
+		CompareType: cp.compareType,
+		Comparator:  cp.comparator,
+	}
+	return mutateRequest
+}
+
+func (cp *CheckAndMutate) CellBlocksEnabled() bool {
+	// cellblocks are not supported for check and mutate request
+	return false
+}

--- a/hrpc/checkandmutate_test.go
+++ b/hrpc/checkandmutate_test.go
@@ -289,7 +289,8 @@ func TestCheckAndMutateWithDifferentMutationTypes(t *testing.T) {
 				t.Fatalf("Failed to create %s mutate: %v", tc.name, err)
 			}
 
-			cam, err := NewCheckAndMutate(mutate, "cf", "col", []byte("expected"), pb.CompareType_EQUAL)
+			cam, err := NewCheckAndMutate(mutate, "cf", "col",
+				[]byte("expected"), pb.CompareType_EQUAL)
 			if err != nil {
 				t.Fatalf("NewCheckAndMutate failed for %s: %v", tc.name, err)
 			}
@@ -300,7 +301,8 @@ func TestCheckAndMutateWithDifferentMutationTypes(t *testing.T) {
 
 			// Verify that the underlying mutate type is preserved
 			if cam.Mutate.mutationType != mutate.mutationType {
-				t.Errorf("Expected mutation type %v, got %v", mutate.mutationType, cam.Mutate.mutationType)
+				t.Errorf("Expected mutation type %v, got %v",
+					mutate.mutationType, cam.Mutate.mutationType)
 			}
 		})
 	}

--- a/hrpc/checkandmutate_test.go
+++ b/hrpc/checkandmutate_test.go
@@ -1,0 +1,306 @@
+// Copyright (C) 2016  The GoHBase Authors.  All rights reserved.
+// This file is part of GoHBase.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+package hrpc
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/tsuna/gohbase/pb"
+)
+
+func TestNewCheckAndMutate(t *testing.T) {
+	ctx := context.Background()
+	table := []byte("test-table")
+	key := []byte("test-key")
+	values := map[string]map[string][]byte{
+		"cf": {"col": []byte("value")},
+	}
+
+	t.Run("ValidInput", func(t *testing.T) {
+		mutate, err := NewPut(ctx, table, key, values)
+		if err != nil {
+			t.Fatalf("Failed to create mutate: %v", err)
+		}
+
+		cam, err := NewCheckAndMutate(mutate, "cf", "col", []byte("expected"), pb.CompareType_EQUAL)
+		if err != nil {
+			t.Fatalf("NewCheckAndMutate failed: %v", err)
+		}
+
+		if cam == nil {
+			t.Fatal("CheckAndMutate should not be nil")
+		}
+
+		if string(cam.family) != "cf" {
+			t.Errorf("Expected family 'cf', got '%s'", string(cam.family))
+		}
+
+		if string(cam.qualifier) != "col" {
+			t.Errorf("Expected qualifier 'col', got '%s'", string(cam.qualifier))
+		}
+
+		if *cam.compareType != pb.CompareType_EQUAL {
+			t.Errorf("Expected compareType EQUAL, got %v", *cam.compareType)
+		}
+
+		if cam.comparator == nil {
+			t.Error("Comparator should not be nil")
+		}
+
+		// Verify that skipBatch is set to true
+		if !mutate.skipbatch {
+			t.Error("Expected skipbatch to be true for CheckAndMutate")
+		}
+	})
+
+	t.Run("NilMutate", func(t *testing.T) {
+		_, err := NewCheckAndMutate(nil, "cf", "col", []byte("expected"), pb.CompareType_EQUAL)
+		if err == nil {
+			t.Error("Expected error for nil mutate")
+		}
+		if err.Error() != "mutate cannot be nil" {
+			t.Errorf("Expected 'mutate cannot be nil', got '%s'", err.Error())
+		}
+	})
+
+	t.Run("EmptyFamily", func(t *testing.T) {
+		mutate, err := NewPut(ctx, table, key, values)
+		if err != nil {
+			t.Fatalf("Failed to create mutate: %v", err)
+		}
+
+		_, err = NewCheckAndMutate(mutate, "", "col", []byte("expected"), pb.CompareType_EQUAL)
+		if err == nil {
+			t.Error("Expected error for empty family")
+		}
+		if err.Error() != "family cannot be empty" {
+			t.Errorf("Expected 'family cannot be empty', got '%s'", err.Error())
+		}
+	})
+
+	t.Run("EmptyQualifier", func(t *testing.T) {
+		mutate, err := NewPut(ctx, table, key, values)
+		if err != nil {
+			t.Fatalf("Failed to create mutate: %v", err)
+		}
+
+		_, err = NewCheckAndMutate(mutate, "cf", "", []byte("expected"), pb.CompareType_EQUAL)
+		if err == nil {
+			t.Error("Expected error for empty qualifier")
+		}
+		if err.Error() != "qualifier cannot be empty" {
+			t.Errorf("Expected 'qualifier cannot be empty', got '%s'", err.Error())
+		}
+	})
+
+	t.Run("DifferentCompareTypes", func(t *testing.T) {
+		mutate, err := NewPut(ctx, table, key, values)
+		if err != nil {
+			t.Fatalf("Failed to create mutate: %v", err)
+		}
+
+		compareTypes := []pb.CompareType{
+			pb.CompareType_EQUAL,
+			pb.CompareType_NOT_EQUAL,
+			pb.CompareType_LESS,
+			pb.CompareType_LESS_OR_EQUAL,
+			pb.CompareType_GREATER,
+			pb.CompareType_GREATER_OR_EQUAL,
+		}
+
+		for _, ct := range compareTypes {
+			cam, err := NewCheckAndMutate(mutate, "cf", "col", []byte("expected"), ct)
+			if err != nil {
+				t.Errorf("NewCheckAndMutate failed for compareType %v: %v", ct, err)
+				continue
+			}
+
+			if *cam.compareType != ct {
+				t.Errorf("Expected compareType %v, got %v", ct, *cam.compareType)
+			}
+		}
+	})
+
+	t.Run("NilExpectedValue", func(t *testing.T) {
+		mutate, err := NewPut(ctx, table, key, values)
+		if err != nil {
+			t.Fatalf("Failed to create mutate: %v", err)
+		}
+
+		cam, err := NewCheckAndMutate(mutate, "cf", "col", nil, pb.CompareType_EQUAL)
+		if err != nil {
+			t.Fatalf("NewCheckAndMutate failed with nil expectedValue: %v", err)
+		}
+
+		if cam == nil {
+			t.Fatal("CheckAndMutate should not be nil")
+		}
+	})
+
+	t.Run("EmptyExpectedValue", func(t *testing.T) {
+		mutate, err := NewPut(ctx, table, key, values)
+		if err != nil {
+			t.Fatalf("Failed to create mutate: %v", err)
+		}
+
+		cam, err := NewCheckAndMutate(mutate, "cf", "col", []byte{}, pb.CompareType_EQUAL)
+		if err != nil {
+			t.Fatalf("NewCheckAndMutate failed with empty expectedValue: %v", err)
+		}
+
+		if cam == nil {
+			t.Fatal("CheckAndMutate should not be nil")
+		}
+	})
+}
+
+func TestCheckAndMutateToProto(t *testing.T) {
+	ctx := context.Background()
+	table := []byte("test-table")
+	key := []byte("test-key")
+	values := map[string]map[string][]byte{
+		"cf": {"col": []byte("value")},
+	}
+
+	mutate, err := NewPut(ctx, table, key, values)
+	if err != nil {
+		t.Fatalf("Failed to create mutate: %v", err)
+	}
+
+	cam, err := NewCheckAndMutate(mutate, "cf", "col", []byte("expected"), pb.CompareType_NOT_EQUAL)
+	if err != nil {
+		t.Fatalf("NewCheckAndMutate failed: %v", err)
+	}
+
+	// Set region before calling ToProto
+	cam.SetRegion(mockRegionInfo([]byte("test-region")))
+
+	protoMsg := cam.ToProto()
+	mutateRequest, ok := protoMsg.(*pb.MutateRequest)
+	if !ok {
+		t.Fatalf("Expected *pb.MutateRequest, got %T", protoMsg)
+	}
+
+	if mutateRequest.Condition == nil {
+		t.Fatal("Condition should not be nil")
+	}
+
+	condition := mutateRequest.Condition
+
+	if !bytes.Equal(condition.Row, key) {
+		t.Errorf("Expected row %v, got %v", key, condition.Row)
+	}
+
+	if !bytes.Equal(condition.Family, []byte("cf")) {
+		t.Errorf("Expected family 'cf', got %v", condition.Family)
+	}
+
+	if !bytes.Equal(condition.Qualifier, []byte("col")) {
+		t.Errorf("Expected qualifier 'col', got %v", condition.Qualifier)
+	}
+
+	if *condition.CompareType != pb.CompareType_NOT_EQUAL {
+		t.Errorf("Expected compareType NOT_EQUAL, got %v", *condition.CompareType)
+	}
+
+	if condition.Comparator == nil {
+		t.Error("Comparator should not be nil")
+	}
+
+	// Verify the comparator is a BinaryComparator
+	if condition.Comparator.Name == nil {
+		t.Error("Comparator name should not be nil")
+	} else if *condition.Comparator.Name != "org.apache.hadoop.hbase.filter.BinaryComparator" {
+		t.Errorf("Expected BinaryComparator, got %s", *condition.Comparator.Name)
+	}
+}
+
+func TestCheckAndMutateCellBlocksEnabled(t *testing.T) {
+	ctx := context.Background()
+	table := []byte("test-table")
+	key := []byte("test-key")
+	values := map[string]map[string][]byte{
+		"cf": {"col": []byte("value")},
+	}
+
+	mutate, err := NewPut(ctx, table, key, values)
+	if err != nil {
+		t.Fatalf("Failed to create mutate: %v", err)
+	}
+
+	cam, err := NewCheckAndMutate(mutate, "cf", "col", []byte("expected"), pb.CompareType_EQUAL)
+	if err != nil {
+		t.Fatalf("NewCheckAndMutate failed: %v", err)
+	}
+
+	if cam.CellBlocksEnabled() {
+		t.Error("CellBlocksEnabled should return false for CheckAndMutate")
+	}
+}
+
+func TestCheckAndMutateWithDifferentMutationTypes(t *testing.T) {
+	ctx := context.Background()
+	table := []byte("test-table")
+	key := []byte("test-key")
+	values := map[string]map[string][]byte{
+		"cf": {"col": []byte("value")},
+	}
+
+	testCases := []struct {
+		name        string
+		createMutate func() (*Mutate, error)
+	}{
+		{
+			name: "Put",
+			createMutate: func() (*Mutate, error) {
+				return NewPut(ctx, table, key, values)
+			},
+		},
+		{
+			name: "Delete",
+			createMutate: func() (*Mutate, error) {
+				return NewDel(ctx, table, key, values)
+			},
+		},
+		{
+			name: "Append",
+			createMutate: func() (*Mutate, error) {
+				return NewApp(ctx, table, key, values)
+			},
+		},
+		{
+			name: "Increment",
+			createMutate: func() (*Mutate, error) {
+				return NewInc(ctx, table, key, values)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mutate, err := tc.createMutate()
+			if err != nil {
+				t.Fatalf("Failed to create %s mutate: %v", tc.name, err)
+			}
+
+			cam, err := NewCheckAndMutate(mutate, "cf", "col", []byte("expected"), pb.CompareType_EQUAL)
+			if err != nil {
+				t.Fatalf("NewCheckAndMutate failed for %s: %v", tc.name, err)
+			}
+
+			if cam == nil {
+				t.Fatalf("CheckAndMutate should not be nil for %s", tc.name)
+			}
+
+			// Verify that the underlying mutate type is preserved
+			if cam.Mutate.mutationType != mutate.mutationType {
+				t.Errorf("Expected mutation type %v, got %v", mutate.mutationType, cam.Mutate.mutationType)
+			}
+		})
+	}
+}

--- a/hrpc/checkandmutate_test.go
+++ b/hrpc/checkandmutate_test.go
@@ -111,6 +111,7 @@ func TestNewCheckAndMutate(t *testing.T) {
 			pb.CompareType_LESS_OR_EQUAL,
 			pb.CompareType_GREATER,
 			pb.CompareType_GREATER_OR_EQUAL,
+			pb.CompareType_NO_OP,
 		}
 
 		for _, ct := range compareTypes {
@@ -252,7 +253,7 @@ func TestCheckAndMutateWithDifferentMutationTypes(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name        string
+		name         string
 		createMutate func() (*Mutate, error)
 	}{
 		{

--- a/integration_test.go
+++ b/integration_test.go
@@ -1600,7 +1600,8 @@ func TestCheckAndMutate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CheckAndMutate error: %s", err)
 		}
-		require.Equal(t, true, camRes, "Expected mutation to execute when current value '5' > expected '3'")
+		require.Equal(t, true, camRes,
+			"Expected mutation to execute when current value '5' > expected '3'")
 
 		// Verify update to "10"
 		g, err := hrpc.NewGetStr(ctx, table, key)
@@ -1624,7 +1625,8 @@ func TestCheckAndMutate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CheckAndMutate error: %s", err)
 		}
-		require.Equal(t, false, camRes, "Expected mutation to NOT execute when current value '10' < expected '15'")
+		require.Equal(t, false, camRes,
+			"Expected mutation to NOT execute when current value '10' < expected '15'")
 
 		// Verify unchanged
 		res, err = c.Get(g)
@@ -1644,7 +1646,8 @@ func TestCheckAndMutate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CheckAndMutate error: %s", err)
 		}
-		require.Equal(t, false, camRes, "Expected mutation to NOT execute when current value '10' == expected '10'")
+		require.Equal(t, false, camRes,
+			"Expected mutation to NOT execute when current value '10' == expected '10'")
 	})
 
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -1508,14 +1508,16 @@ func TestCheckAndMutate(t *testing.T) {
 				t.Fatalf("NewCheckAndMutate returned an error: %v", err)
 			}
 
-			casRes, err := c.CheckAndMutate(putRequest, ef, eq, tt.inExpectedValue, pb.CompareType_EQUAL)
+			casRes, err := c.CheckAndMutate(putRequest, ef, eq,
+				tt.inExpectedValue, pb.CompareType_EQUAL)
 
 			if err != nil {
 				t.Fatalf("CheckAndMutate error: %s", err)
 			}
 
 			if casRes != tt.out {
-				t.Errorf("CheckAndMutate with put values=%q and expectedValue=%q returned %v, want %v",
+				t.Errorf(
+					"CheckAndMutate with put values=%q and expectedValue=%q returned %v, want %v",
 					tt.inValues, tt.inExpectedValue, casRes, tt.out)
 			}
 		}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1524,11 +1524,11 @@ func TestCheckAndMutate(t *testing.T) {
 	})
 
 	t.Run("Not Equals", func(t *testing.T) {
+		k := "cam.ne.1"
+
 		ctx := context.Background()
 
-		// {}
-
-		p, err := hrpc.NewPut(ctx, []byte(table), []byte(key), makeValues("c", "1"))
+		p, err := hrpc.NewPut(ctx, []byte(table), []byte(k), makeValues(k, "1"))
 		if err != nil {
 			t.Fatalf("NewPut returned an error: %v", err)
 		}
@@ -1537,7 +1537,7 @@ func TestCheckAndMutate(t *testing.T) {
 			t.Fatalf("Put returned an error: %v", err)
 		}
 
-		g, err := hrpc.NewGetStr(ctx, table, key)
+		g, err := hrpc.NewGetStr(ctx, table, k)
 		if err != nil {
 			t.Fatalf("NewGet returned an error: %v", err)
 		}
@@ -1552,7 +1552,7 @@ func TestCheckAndMutate(t *testing.T) {
 
 		// {"c": "1"}
 
-		putRequest, err := hrpc.NewPutStr(context.Background(), table, key, makeValues("c", "2"))
+		putRequest, err := hrpc.NewPutStr(context.Background(), table, key, makeValues(k, "2"))
 		if err != nil {
 			t.Fatalf("NewCheckAndMutate returned an error: %v", err)
 		}
@@ -1564,7 +1564,7 @@ func TestCheckAndMutate(t *testing.T) {
 
 		// {"c": "2"}
 
-		putRequest, err = hrpc.NewPutStr(context.Background(), table, key, makeValues("c", "3"))
+		putRequest, err = hrpc.NewPutStr(context.Background(), table, key, makeValues(k, "3"))
 		if err != nil {
 			t.Fatalf("NewCheckAndMutate returned an error: %v", err)
 		}
@@ -1579,10 +1579,11 @@ func TestCheckAndMutate(t *testing.T) {
 	})
 
 	t.Run("Greater", func(t *testing.T) {
+		k := "cam.greater.1"
+
 		ctx := context.Background()
 
-		// {"a": "5"}
-		p, err := hrpc.NewPut(ctx, []byte(table), []byte(key), makeValues("a", "5"))
+		p, err := hrpc.NewPut(ctx, []byte(table), []byte(key), makeValues(key, "5"))
 		if err != nil {
 			t.Fatalf("NewPut returned an error: %v", err)
 		}
@@ -1592,7 +1593,7 @@ func TestCheckAndMutate(t *testing.T) {
 		}
 
 		// check "5" > expected "3", should mutate
-		putRequest, err := hrpc.NewPutStr(ctx, table, key, makeValues("a", "10"))
+		putRequest, err := hrpc.NewPutStr(ctx, table, key, makeValues(key, "10"))
 		if err != nil {
 			t.Fatalf("NewPutStr returned an error: %v", err)
 		}
@@ -1617,7 +1618,7 @@ func TestCheckAndMutate(t *testing.T) {
 		require.Equal(t, []byte("10"), res.Cells[0].Value, "Value should be updated to '10'")
 
 		// check "10" > expected "15", should not mutate
-		putRequest, err = hrpc.NewPutStr(ctx, table, key, makeValues("a", "20"))
+		putRequest, err = hrpc.NewPutStr(ctx, table, key, makeValues(key, "20"))
 		if err != nil {
 			t.Fatalf("NewPutStr returned an error: %v", err)
 		}
@@ -1638,7 +1639,7 @@ func TestCheckAndMutate(t *testing.T) {
 		require.Equal(t, []byte("10"), res.Cells[0].Value, "Value should remain '10'")
 
 		// check "10" > expected "10", should not mutate
-		putRequest, err = hrpc.NewPutStr(ctx, table, key, makeValues("a", "30"))
+		putRequest, err = hrpc.NewPutStr(ctx, table, key, makeValues(key, "30"))
 		if err != nil {
 			t.Fatalf("NewPutStr returned an error: %v", err)
 		}

--- a/test/mock/client.go
+++ b/test/mock/client.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	hrpc "github.com/tsuna/gohbase/hrpc"
+	pb "github.com/tsuna/gohbase/pb"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -21,6 +22,7 @@ import (
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
+	isgomock struct{}
 }
 
 // MockClientMockRecorder is the mock recorder for MockClient.
@@ -41,47 +43,62 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Append mocks base method.
-func (m *MockClient) Append(arg0 *hrpc.Mutate) (*hrpc.Result, error) {
+func (m *MockClient) Append(a *hrpc.Mutate) (*hrpc.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Append", arg0)
+	ret := m.ctrl.Call(m, "Append", a)
 	ret0, _ := ret[0].(*hrpc.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Append indicates an expected call of Append.
-func (mr *MockClientMockRecorder) Append(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) Append(a any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Append", reflect.TypeOf((*MockClient)(nil).Append), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Append", reflect.TypeOf((*MockClient)(nil).Append), a)
 }
 
 // CacheRegions mocks base method.
-func (m *MockClient) CacheRegions(arg0 []byte) error {
+func (m *MockClient) CacheRegions(table []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheRegions", arg0)
+	ret := m.ctrl.Call(m, "CacheRegions", table)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CacheRegions indicates an expected call of CacheRegions.
-func (mr *MockClientMockRecorder) CacheRegions(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) CacheRegions(table any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheRegions", reflect.TypeOf((*MockClient)(nil).CacheRegions), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheRegions", reflect.TypeOf((*MockClient)(nil).CacheRegions), table)
+}
+
+// CheckAndMutate mocks base method.
+func (m *MockClient) CheckAndMutate(p *hrpc.Mutate, family, qualifier string, expectedValue []byte, compareType pb.CompareType) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckAndMutate", p, family, qualifier, expectedValue, compareType)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckAndMutate indicates an expected call of CheckAndMutate.
+func (mr *MockClientMockRecorder) CheckAndMutate(p, family, qualifier, expectedValue, compareType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckAndMutate", reflect.TypeOf((*MockClient)(nil).CheckAndMutate), p, family, qualifier, expectedValue, compareType)
 }
 
 // CheckAndPut mocks base method.
-func (m *MockClient) CheckAndPut(arg0 *hrpc.Mutate, arg1, arg2 string, arg3 []byte) (bool, error) {
+func (m *MockClient) CheckAndPut(p *hrpc.Mutate, family, qualifier string, expectedValue []byte) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckAndPut", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "CheckAndPut", p, family, qualifier, expectedValue)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CheckAndPut indicates an expected call of CheckAndPut.
-func (mr *MockClientMockRecorder) CheckAndPut(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockClientMockRecorder) CheckAndPut(p, family, qualifier, expectedValue any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckAndPut", reflect.TypeOf((*MockClient)(nil).CheckAndPut), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckAndPut", reflect.TypeOf((*MockClient)(nil).CheckAndPut), p, family, qualifier, expectedValue)
 }
 
 // Close mocks base method.
@@ -97,90 +114,90 @@ func (mr *MockClientMockRecorder) Close() *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockClient) Delete(arg0 *hrpc.Mutate) (*hrpc.Result, error) {
+func (m *MockClient) Delete(d *hrpc.Mutate) (*hrpc.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0)
+	ret := m.ctrl.Call(m, "Delete", d)
 	ret0, _ := ret[0].(*hrpc.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockClientMockRecorder) Delete(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) Delete(d any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), d)
 }
 
 // Get mocks base method.
-func (m *MockClient) Get(arg0 *hrpc.Get) (*hrpc.Result, error) {
+func (m *MockClient) Get(g *hrpc.Get) (*hrpc.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0)
+	ret := m.ctrl.Call(m, "Get", g)
 	ret0, _ := ret[0].(*hrpc.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockClientMockRecorder) Get(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) Get(g any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), g)
 }
 
 // Increment mocks base method.
-func (m *MockClient) Increment(arg0 *hrpc.Mutate) (int64, error) {
+func (m *MockClient) Increment(i *hrpc.Mutate) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Increment", arg0)
+	ret := m.ctrl.Call(m, "Increment", i)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Increment indicates an expected call of Increment.
-func (mr *MockClientMockRecorder) Increment(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) Increment(i any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Increment", reflect.TypeOf((*MockClient)(nil).Increment), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Increment", reflect.TypeOf((*MockClient)(nil).Increment), i)
 }
 
 // Put mocks base method.
-func (m *MockClient) Put(arg0 *hrpc.Mutate) (*hrpc.Result, error) {
+func (m *MockClient) Put(p *hrpc.Mutate) (*hrpc.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", arg0)
+	ret := m.ctrl.Call(m, "Put", p)
 	ret0, _ := ret[0].(*hrpc.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockClientMockRecorder) Put(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) Put(p any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockClient)(nil).Put), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockClient)(nil).Put), p)
 }
 
 // Scan mocks base method.
-func (m *MockClient) Scan(arg0 *hrpc.Scan) hrpc.Scanner {
+func (m *MockClient) Scan(s *hrpc.Scan) hrpc.Scanner {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Scan", arg0)
+	ret := m.ctrl.Call(m, "Scan", s)
 	ret0, _ := ret[0].(hrpc.Scanner)
 	return ret0
 }
 
 // Scan indicates an expected call of Scan.
-func (mr *MockClientMockRecorder) Scan(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) Scan(s any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scan", reflect.TypeOf((*MockClient)(nil).Scan), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scan", reflect.TypeOf((*MockClient)(nil).Scan), s)
 }
 
 // SendBatch mocks base method.
-func (m *MockClient) SendBatch(arg0 context.Context, arg1 []hrpc.Call) ([]hrpc.RPCResult, bool) {
+func (m *MockClient) SendBatch(ctx context.Context, batch []hrpc.Call) ([]hrpc.RPCResult, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendBatch", arg0, arg1)
+	ret := m.ctrl.Call(m, "SendBatch", ctx, batch)
 	ret0, _ := ret[0].([]hrpc.RPCResult)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // SendBatch indicates an expected call of SendBatch.
-func (mr *MockClientMockRecorder) SendBatch(arg0, arg1 any) *gomock.Call {
+func (mr *MockClientMockRecorder) SendBatch(ctx, batch any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendBatch", reflect.TypeOf((*MockClient)(nil).SendBatch), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendBatch", reflect.TypeOf((*MockClient)(nil).SendBatch), ctx, batch)
 }


### PR DESCRIPTION
Adds the wrapper for [CheckAndMutate HRPC calls]([https://hbase.apache.org/2.5/apidocs/org/apache/hadoop/hbase/client/CheckAndMutate.html]). Although general Mutation functionality somewhat exists through the CheckAndPut operation, [we don't allow any kind of mutations besides Puts](https://github.com/tsuna/gohbase/blob/master/hrpc/checkandput.go#L32). This PR introduces a new binding for `CheckAndMutate` that neatly exposes this new behavior.