### PR TITLE
Resizable semaphore

### DIFF
--- a/region/sema.go
+++ b/region/sema.go
@@ -1,0 +1,112 @@
+// Copyright (C) 2025  The GoHBase Authors.  All rights reserved.
+// This file is part of GoHBase.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+package region
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// semaphore implements a resizable semaphore
+type semaphore struct {
+	c chan token
+
+	mu sync.Mutex
+	// ballast is the desired count of tokens in c that is used to
+	// restrict the size of the semaphore.
+	ballast int
+	// curBallast is the actual number of tokens in c that is used to
+	// restrict the size of the semaphore. curBallast can be lower
+	// than ballast, in which case calls to Release() aids in
+	// increasing ballast.
+	curBallast int
+}
+
+type token = struct{}
+
+// newSemaphore creates a new Semaphore with a given maxSize. The
+// semaphore cannot be resized larger than maxSize.
+func newSemaphore(maxSize int) *semaphore {
+	return &semaphore{c: make(chan token, maxSize)}
+}
+
+// maxSize returns the maximum size of this semaphore
+func (s *semaphore) maxSize() int {
+	return cap(s.c)
+}
+
+// size returns the current size of the semaphore, set by the most recent call to Resize.
+func (s *semaphore) size() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxSize() - s.ballast
+}
+
+// acquire blocks until there is available capacity in the semaphore.
+func (s *semaphore) acquire(ctx context.Context) error {
+	select {
+	case s.c <- token{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// release releases capacity in the semaphore. This function never blocks.
+func (s *semaphore) release() {
+	if s.incBallast() {
+		return
+	}
+	select {
+	case <-s.c:
+	default:
+		panic(errors.New("Release called more than Acquire"))
+	}
+}
+
+func (s *semaphore) incBallast() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.curBallast < s.ballast {
+		s.curBallast++
+		return true
+	}
+	return false
+}
+
+// resize puts a new limit on the size of the semaphore. The size must
+// be between 0 and maxSize, inclusive. This function never blocks.
+func (s *semaphore) resize(size int) {
+	if size < 0 || size > s.maxSize() {
+		panic(fmt.Errorf("resize must be between 0 and maxSize, got %d", size))
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ballast = s.maxSize() - size
+
+	// Release ballast if there is too much.
+	for s.curBallast > s.ballast {
+		select {
+		case <-s.c:
+			s.curBallast--
+		default:
+			panic(errors.New("Release called more than Acquire"))
+		}
+	}
+
+	// Add ballast if there's not enough. Return early if adding ballast would block.
+	// Any remaining ballast will be added by Release.
+	for s.curBallast < s.ballast {
+		select {
+		case s.c <- token{}:
+			s.curBallast++
+		default:
+			return
+		}
+	}
+}

--- a/region/sema_test.go
+++ b/region/sema_test.go
@@ -1,0 +1,149 @@
+// Copyright (C) 2025  The GoHBase Authors.  All rights reserved.
+// This file is part of GoHBase.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+// Limiting to go1.25 because this test uses testing/synctest, only available in go1.25
+//go:build go1.25
+
+package region
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"testing/synctest"
+)
+
+func TestSemaphore(t *testing.T) {
+	goAcquire := func(ctx context.Context, s *semaphore) (*bool, *error) {
+		var (
+			done bool
+			err  error
+		)
+		go func() {
+			err = s.acquire(ctx)
+			done = true
+		}()
+		return &done, &err
+	}
+	synctest.Test(t, func(t *testing.T) {
+		s := newSemaphore(3)
+		s.acquire(context.Background())
+		s.acquire(context.Background())
+		s.acquire(context.Background())
+
+		done, err := goAcquire(context.Background(), s)
+		synctest.Wait()
+		if *done {
+			t.Fatal("acquire should block")
+		}
+		s.release()
+		synctest.Wait()
+		if !*done {
+			t.Fatal("acquire should have completed")
+		} else if *err != nil {
+			t.Fatalf("unexpected error: %s", *err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done, err = goAcquire(ctx, s)
+		synctest.Wait()
+		if *done {
+			t.Fatal("acquire should have blocked")
+		}
+		cancel()
+		synctest.Wait()
+		if !*done {
+			t.Fatal("acquire should have completed")
+		} else if *err != context.Canceled {
+			t.Errorf("unexpected error: %s", *err)
+		}
+
+		// Test resize down
+		s.release()
+		s.resize(1)
+		done, err = goAcquire(context.Background(), s)
+		synctest.Wait()
+		if *done {
+			t.Fatal("acquire should have blocked")
+		}
+		s.release()
+		synctest.Wait()
+		if *done {
+			t.Fatal("acquire should have blocked")
+		}
+		s.release()
+		synctest.Wait()
+		if !*done {
+			t.Fatal("acquire should have completed")
+		}
+
+		// Test resize up unblocks Acquirers
+		// assumes ordering when blocked on channel
+		done1, err1 := goAcquire(context.Background(), s)
+		synctest.Wait()
+		done2, err2 := goAcquire(context.Background(), s)
+		synctest.Wait()
+		done3, err3 := goAcquire(context.Background(), s)
+		synctest.Wait()
+		if *done1 || *done2 || *done3 {
+			t.Fatal("acquires should have blocked")
+		}
+		s.resize(3)
+		synctest.Wait()
+		if !*done1 || !*done2 {
+			t.Fatal("two acquires should have completed")
+		}
+		if *done3 {
+			t.Fatal("last acquire should block")
+		}
+		s.release()
+		synctest.Wait()
+		if !*done3 {
+			t.Fatal("acquire should have completed")
+		}
+		if *err1 != nil || *err2 != nil || *err3 != nil {
+			t.Fatalf("unexpected errors: %v, %v, %v", *err1, *err2, *err3)
+		}
+	})
+}
+
+// TestRace starts multiple goroutines acquiring, releasing,
+// and resizing a single semaphore in parallel.
+func TestRace(t *testing.T) {
+	const (
+		semaMaxSize = 5
+
+		acquirers    = 6
+		acquireCount = 10
+
+		resizers    = 2
+		resizeCount = 10
+	)
+	s := newSemaphore(semaMaxSize)
+	var wg sync.WaitGroup
+	for range acquirers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range acquireCount {
+				s.acquire(context.Background())
+				s.release()
+			}
+		}()
+	}
+
+	for range resizers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range resizeCount {
+				s.resize(0)
+				s.resize(semaMaxSize)
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Add a resizeable semaphore implementation. To be used with the congestion control code.