### PR TITLE
Upgrade hbase to 2.6.2 for integration tests and github action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         go: [~1.24, ^1]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup | Download HBase
         run: |
@@ -38,7 +38,7 @@ jobs:
         run: hbase/bin/hbase-daemon.sh --config hbase/conf start master
 
       - name: Setup | Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
 
@@ -52,7 +52,7 @@ jobs:
         run: make integration_cover HBASE_HOME=hbase
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v5
 
       - name: Upload HBase logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
`PrefixFilter` has changed in hbase 2.6.2 so that scanning hbase:meta for prefix `$table_name,` does not return any rows, but scanning with prefix `$table_name` or `$table_name,,` does return rows.

Example
2.4.6:
```
create "my_test_table", "cf1"

hbase:012:0> scan 'hbase:meta', {FILTER => org.apache.hadoop.hbase.filter.PrefixFilter.new('my_test_table,'.to_java_bytes)}
ROW                                                              COLUMN+CELL
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:regioninfo, timestamp=2025-11-04T07:54:22.706, value={ENCODED => eddb128947690b86a87bf113efcfd851, NAME => 'my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.', ST
                                                                 ARTKEY => '', ENDKEY => ''}
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:seqnumDuringOpen, timestamp=2025-11-04T07:54:22.706, value=\x00\x00\x00\x00\x00\x00\x00\x02
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:server, timestamp=2025-11-04T07:54:22.706, value=127.0.0.1:16020
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:serverstartcode, timestamp=2025-11-04T07:54:22.706, value=1762242833683
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:sn, timestamp=2025-11-04T07:54:22.528, value=127.0.0.1,16020,1762242833683
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:state, timestamp=2025-11-04T07:54:22.706, value=OPEN
1 row(s)

hbase:013:0> scan 'hbase:meta', {FILTER => org.apache.hadoop.hbase.filter.PrefixFilter.new('my_test_table,,'.to_java_bytes)}
ROW                                                              COLUMN+CELL
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:regioninfo, timestamp=2025-11-04T07:54:22.706, value={ENCODED => eddb128947690b86a87bf113efcfd851, NAME => 'my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.', ST
                                                                 ARTKEY => '', ENDKEY => ''}
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:seqnumDuringOpen, timestamp=2025-11-04T07:54:22.706, value=\x00\x00\x00\x00\x00\x00\x00\x02
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:server, timestamp=2025-11-04T07:54:22.706, value=127.0.0.1:16020
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:serverstartcode, timestamp=2025-11-04T07:54:22.706, value=1762242833683
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:sn, timestamp=2025-11-04T07:54:22.528, value=127.0.0.1,16020,1762242833683
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:state, timestamp=2025-11-04T07:54:22.706, value=OPEN
1 row(s)

hbase:014:0> scan 'hbase:meta', {FILTER => org.apache.hadoop.hbase.filter.PrefixFilter.new('my_test_table'.to_java_bytes)}
ROW                                                              COLUMN+CELL
 my_test_table                                                   column=table:state, timestamp=2025-11-04T07:54:22.710, value=\x08\x00
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:regioninfo, timestamp=2025-11-04T07:54:22.706, value={ENCODED => eddb128947690b86a87bf113efcfd851, NAME => 'my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.', ST
                                                                 ARTKEY => '', ENDKEY => ''}
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:seqnumDuringOpen, timestamp=2025-11-04T07:54:22.706, value=\x00\x00\x00\x00\x00\x00\x00\x02
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:server, timestamp=2025-11-04T07:54:22.706, value=127.0.0.1:16020
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:serverstartcode, timestamp=2025-11-04T07:54:22.706, value=1762242833683
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:sn, timestamp=2025-11-04T07:54:22.528, value=127.0.0.1,16020,1762242833683
 my_test_table,,1762242862276.eddb128947690b86a87bf113efcfd851.  column=info:state, timestamp=2025-11-04T07:54:22.706, value=OPEN
2 row(s)
```

2.6.2:
```
create "my_test_table", "cf1"

hbase:001:0> scan 'hbase:meta', {FILTER => org.apache.hadoop.hbase.filter.PrefixFilter.new('my_test_table,'.to_java_bytes)}
scan 'hbase:meta', {FILTER => org.apache.hadoop.hbase.filter.PrefixFilter.new('my_test_table,'.to_java_bytes)}
ROW  COLUMN+CELL
0 row(s)

hbase:002:0> scan 'hbase:meta', {FILTER => org.apache.hadoop.hbase.filter.PrefixFilter.new('my_test_table,,'.to_java_bytes)}
scan 'hbase:meta', {FILTER => org.apache.hadoop.hbase.filter.PrefixFilter.new('my_test_table,,'.to_java_bytes)}
ROW  COLUMN+CELL
 my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989. column=info:regioninfo, timestamp=2025-11-04T08:02:00.645, value={ENCODED => a07689c7f16a0633c198131c5b124989, NAME => 'my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989.', STARTKEY => '', ENDKEY => ''}
 my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989. column=info:seqnumDuringOpen, timestamp=2025-11-04T08:02:00.645, value=\x00\x00\x00\x00\x00\x00\x00\x02
 my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989. column=info:server, timestamp=2025-11-04T08:02:00.645, value=home-host-1:16020
 my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989. column=info:serverstartcode, timestamp=2025-11-04T08:02:00.645, value=1762243256242
 my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989. column=info:sn, timestamp=2025-11-04T08:02:00.394, value=home-host-1,16020,1762243256242
 my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989. column=info:state, timestamp=2025-11-04T08:02:00.645, value=OPEN
1 row(s)

hbase:003:0> scan 'hbase:meta', {FILTER => org.apache.hadoop.hbase.filter.PrefixFilter.new('my_test_table'.to_java_bytes)}
scan 'hbase:meta', {FILTER => org.apache.hadoop.hbase.filter.PrefixFilter.new('my_test_table'.to_java_bytes)}
ROW  COLUMN+CELL
 my_test_table column=table:state, timestamp=2025-11-04T07:46:53.787, value=\x08\x00
 my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989. column=info:regioninfo, timestamp=2025-11-04T08:02:00.645, value={ENCODED => a07689c7f16a0633c198131c5b124989, NAME => 'my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989.', STARTKEY => '', ENDKEY => ''}
 my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989. column=info:seqnumDuringOpen, timestamp=2025-11-04T08:02:00.645, value=\x00\x00\x00\x00\x00\x00\x00\x02
 my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989. column=info:server, timestamp=2025-11-04T08:02:00.645, value=home-host-1:16020
 my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989. column=info:serverstartcode, timestamp=2025-11-04T08:02:00.645, value=1762243256242
 my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989. column=info:sn, timestamp=2025-11-04T08:02:00.394, value=home-host-1,16020,1762243256242
 my_test_table,,1762242412039.a07689c7f16a0633c198131c5b124989. column=info:state, timestamp=2025-11-04T08:02:00.645, value=OPEN
2 row(s)
```

Unclear which exact change in hbase caused this change. Updating the tests to use different prefixes to work around this issue for now.