### PR TITLE
hrpc: Move Scan's ResponseSize into ScanResponseV2

### DIFF
--- a/hrpc/scan.go
+++ b/hrpc/scan.go
@@ -70,6 +70,11 @@ type ScanResponseV2 struct {
 	// Results contains ResultV2s, each of which are the results for a
 	// single row.
 	Results []ResultV2
+
+	// ResponseSize contains the size of the response after the RPC is
+	// completed. It is the size of the uncompressed cellblocks in the
+	// response.
+	ResponseSize int
 }
 
 // ResultV2 contains the results for a single row.
@@ -133,12 +138,6 @@ type Scan struct {
 
 	scanStatsHandler ScanStatsHandler
 	scanStatsID      int64
-
-	// ResponseSize contains the size of the response after the RPC is
-	// completed. It is the size of the uncompressed cellblocks in the
-	// response. This is only meant for use internal to gohbase.
-	// TODO: Move this inside ScanResponse
-	ResponseSize int
 
 	// Response contains the scan's response after the RPC is
 	// completed. This is only meant for use internal to gohbase.
@@ -396,7 +395,7 @@ func (s *Scan) DeserializeCellBlocks(m proto.Message, b []byte) (uint32, error) 
 		}
 		readLen += l
 	}
-	s.ResponseSize = int(readLen)
+	s.Response.ResponseSize = int(readLen)
 	return readLen, nil
 }
 

--- a/rpc.go
+++ b/rpc.go
@@ -186,7 +186,9 @@ func (c *client) scanRpcScanStats(scan *hrpc.Scan, resp proto.Message, err error
 			stats.Error = true
 		}
 		stats.Retryable = retry
-		stats.ResponseSize = scan.ResponseSize
+		if scan.Response != nil {
+			stats.ResponseSize = scan.Response.ResponseSize
+		}
 		scan.ScanStatsHandler()(stats)
 	}
 }

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1928,8 +1928,8 @@ func TestSendRPCStatsHandler(t *testing.T) {
 				t.Fatalf("Failed to create scan req: %v", err)
 			}
 			expectedScanStatsID := scan.ScanStatsID()
-			scan.ResponseSize = 42
-			expectedResponseSize := scan.ResponseSize
+			scan.Response = &hrpc.ScanResponseV2{ResponseSize: 42}
+			expectedResponseSize := scan.Response.ResponseSize
 
 			go func() {
 				res := hrpc.RPCResult{


### PR DESCRIPTION
This allows callers of ScanV2 to get the ResponseSize.