### PR TITLE
Add ScanStatsHandler to continue scans

### DIFF
--- a/hrpc/scan.go
+++ b/hrpc/scan.go
@@ -564,9 +564,6 @@ func WithScanStatsHandler(h ScanStatsHandler) func(Call) error {
 		if !ok {
 			return errors.New("'WithScanStatsHandler' option can only be used with Scan queries")
 		}
-		if h == nil {
-			return errors.New("'WithScanStatsHandler' must provide a handler function")
-		}
 		scan.scanStatsHandler = h
 		return nil
 	}

--- a/hrpc/scan_test.go
+++ b/hrpc/scan_test.go
@@ -34,11 +34,6 @@ func TestWithScanStatsHandler(t *testing.T) {
 		t.Fatal("ScanStatsHandler nil, want it to be set")
 	}
 
-	s, err = NewScan(ctx, table, WithScanStatsHandler(nil))
-	if err == nil {
-		t.Fatal("nil handler should have returned an error")
-	}
-
 	_, err = NewGet(ctx, table, []byte("random key"), WithScanStatsHandler(h))
 	if err == nil {
 		t.Fatal("Should not have been able to create non-Scan request without error")

--- a/integration_test.go
+++ b/integration_test.go
@@ -3000,10 +3000,9 @@ func TestScanWithStatsHandler(t *testing.T) {
 
 			// keySplits is used to split the table into pre-split regions. For this scan,
 			// the number of ScanStats results (and hrpc.Results, although not tested here) should
-			// equal the num regions in the table. The test is scanning a tiny amount of data
-			// it has written to specified qualifiers, so wouldn't be hitting max result size, ex.
-			if len(statsRes) != len(keySplits)+1 {
-				t.Fatalf("Expected handler to be called %d times, got %d calls",
+			// equal about the num regions in the table.
+			if len(statsRes) < len(keySplits)+1 {
+				t.Fatalf("Expected handler to be called more than %d times, got %d calls",
 					len(keySplits)+1, len(statsRes))
 			}
 

--- a/scanner.go
+++ b/scanner.go
@@ -279,6 +279,7 @@ func (s *scanner) request() (*hrpc.ScanResponseV2, *pb.ScanResponse, hrpc.Region
 			hrpc.RenewInterval(s.rpc.RenewInterval()),
 			// preserve ScanStatsID
 			hrpc.ScanStatsID(s.rpc.ScanStatsID()),
+			hrpc.WithScanStatsHandler(s.rpc.ScanStatsHandler()),
 		)
 	}
 	if err != nil {


### PR DESCRIPTION
This fixes a bug where the ScanStatsHandler doesn't get called on scans that continue within a region.