### PR TITLE
Restore Renewer fixes. (#324) with startRow

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -89,11 +89,12 @@ func (s *scanner) peek() (hrpc.ResultV2, error) {
 	if err != nil {
 		return hrpc.ResultV2{}, err
 	}
-	if !s.closed && s.rpc.RenewInterval() > 0 {
-		// Start up a renewer
+	if !s.isRegionScannerClosed() && s.rpc.RenewInterval() > 0 {
+		// Start up a renewer if there is more to read within this
+		// region.
 		renewCtx, cancel := context.WithCancel(s.rpc.Context())
 		s.renewCancel = cancel
-		go s.renewLoop(renewCtx, s.startRow)
+		go s.renewLoop(renewCtx, s.curRegionScannerID, s.startRow)
 	}
 
 	// fetch cannot return zero results
@@ -229,11 +230,12 @@ func (s *scannerV2) Next() (*hrpc.ScanResponseV2, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !s.closed && s.rpc.RenewInterval() > 0 {
-		// Start up a renewer
+	if !s.isRegionScannerClosed() && s.rpc.RenewInterval() > 0 {
+		// Start up a renewer if there is more to read within this
+		// region.
 		renewCtx, cancel := context.WithCancel(s.rpc.Context())
 		s.renewCancel = cancel
-		go s.renewLoop(renewCtx, s.startRow)
+		go s.renewLoop(renewCtx, s.curRegionScannerID, s.startRow)
 	}
 	return resp, nil
 }
@@ -423,7 +425,7 @@ func (s *scanner) closeRegionScanner() {
 }
 
 // renews a scanner by resending scan request with renew = true
-func (s *scanner) renew(ctx context.Context, startRow []byte) error {
+func (s *scanner) renew(ctx context.Context, scannerID uint64, startRow []byte) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -431,7 +433,7 @@ func (s *scanner) renew(ctx context.Context, startRow []byte) error {
 		s.rpc.Table(),
 		startRow,
 		nil,
-		hrpc.ScannerID(s.curRegionScannerID),
+		hrpc.ScannerID(scannerID),
 		hrpc.Priority(s.rpc.Priority()),
 		hrpc.RenewalScan(),
 		hrpc.ScanStatsID(s.rpc.ScanStatsID()),
@@ -443,7 +445,7 @@ func (s *scanner) renew(ctx context.Context, startRow []byte) error {
 	return err
 }
 
-func (s *scanner) renewLoop(ctx context.Context, startRow []byte) {
+func (s *scanner) renewLoop(ctx context.Context, scannerID uint64, startRow []byte) {
 	scanRenewers.Inc()
 	t := time.NewTicker(s.rpc.RenewInterval())
 	defer func() {
@@ -454,7 +456,7 @@ func (s *scanner) renewLoop(ctx context.Context, startRow []byte) {
 	for {
 		select {
 		case <-t.C:
-			if err := s.renew(ctx, startRow); err != nil {
+			if err := s.renew(ctx, scannerID, startRow); err != nil {
 				s.logger.Error("error renewing scanner", "err", err)
 				return
 			}


### PR DESCRIPTION
startRow must be retained in the scanner renewal request because it is used for region lookup in SendRPC (even though the startRow is not used by HBase itself to renew the scanner).