### PR TITLE
region: Add scan_queue_latency metric

### DIFF
--- a/region/client.go
+++ b/region/client.go
@@ -339,9 +339,11 @@ func (c *client) registerRPC(rpc hrpc.Call) (uint32, error) {
 	// If Take() returns an error the token is not taken
 	if _, isScan := rpc.(*hrpc.Scan); isScan && c.scanTokenBucket != nil &&
 		hrpc.GetPriority(rpc) == 0 {
+		t := time.Now()
 		if err := c.scanTokenBucket.Take(rpc.Context()); err != nil {
 			return 0, err
 		}
+		scanQueueLatency.WithLabelValues(c.addr).Observe(time.Since(t).Seconds())
 	}
 
 	if _, isMulti := rpc.(*multi); isMulti && c.batchRequestsTokenBucket != nil {

--- a/region/prometheus.go
+++ b/region/prometheus.go
@@ -70,6 +70,16 @@ var (
 		[]string{"regionserver"},
 	)
 
+	scanQueueLatency = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "gohbase",
+			Name:      "scan_queue_latency_seconds",
+			Help:      "Time spent waiting to execute a scan request",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 17),
+		},
+		[]string{"regionserver"},
+	)
+
 	concurrentBatchRequests = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "gohbase",


### PR DESCRIPTION
Add a histogram to track the amount of time spent waiting in the scan queue.

A heavily loaded region server may have concurrent scans limit drop to a minimal value, and we can observe this with existing metrics, but this only tells part of the story. To see the impact of the loaded regionserver we need the amount of time a request spends waiting to execute.