### PR TITLE
Add RPCObserver interface to encapsulate stats handling; Record ScanStats start time after congestion queue

### DIFF
--- a/hrpc/call.go
+++ b/hrpc/call.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"time"
 	"unsafe"
 
 	"github.com/tsuna/gohbase/pb"
@@ -61,6 +62,18 @@ type Call interface {
 	ResultChan() chan RPCResult
 	Description() string // Used for tracing and metrics
 	Context() context.Context
+}
+
+// RPCObserver is optionally implemented by RPCs that track
+// per-attempt timing and completion statistics.
+type RPCObserver interface {
+	// SetSendTime is called by the region client right after the RPC clears
+	// congestion control (registerRPC), before marshaling and writing to the wire.
+	SetSendTime(time.Time)
+
+	// OnComplete is called after each RPC attempt with the response,
+	// error, and whether the error is retryable.
+	OnComplete(msg proto.Message, err error, retryable bool)
 }
 
 type withOptions interface {

--- a/hrpc/scan.go
+++ b/hrpc/scan.go
@@ -156,6 +156,7 @@ type Scan struct {
 
 	scanStatsHandler ScanStatsHandler
 	scanStatsID      int64
+	sendTime         time.Time
 
 	// Response contains the scan's response after the RPC is
 	// completed. This is only meant for use internal to gohbase.
@@ -321,6 +322,52 @@ func (s *Scan) ScannerId() uint64 {
 // ScanStatsID provides an ID assigned to this scan for collecting ScanStats
 func (s *Scan) ScanStatsID() int64 {
 	return s.scanStatsID
+}
+
+// SetSendTime implements RPCObserver. It is called by the region client
+// right after congestion control releases the RPC.
+func (s *Scan) SetSendTime(t time.Time) {
+	s.sendTime = t
+}
+
+// OnComplete implements RPCObserver. It is called after each RPC attempt
+// to deliver scan statistics to the registered ScanStatsHandler.
+func (s *Scan) OnComplete(msg proto.Message, err error, retryable bool) {
+	if s.scanStatsHandler == nil {
+		return
+	}
+
+	stats := &ScanStats{
+		Table:       s.table,
+		StartRow:    s.startRow,
+		EndRow:      s.stopRow,
+		ScannerID:   s.scannerID,
+		ScanStatsID: s.scanStatsID,
+		Start:       s.sendTime,
+		End:         time.Now(),
+		Error:       err != nil,
+		Retryable:   retryable,
+	}
+
+	if s.trackScanMetrics && msg != nil {
+		if scanres, ok := msg.(*pb.ScanResponse); ok && scanres.ScanMetrics != nil {
+			stats.ScanMetrics = make(map[string]int64)
+			for _, m := range scanres.ScanMetrics.GetMetrics() {
+				stats.ScanMetrics[m.GetName()] = m.GetValue()
+			}
+		}
+	}
+
+	if reg := s.Region(); reg != nil {
+		stats.RegionID = reg.ID()
+		if cl := reg.Client(); cl != nil {
+			stats.RegionServer = cl.Addr()
+		}
+	}
+	if s.Response != nil {
+		stats.ResponseSize = s.Response.ResponseSize
+	}
+	s.scanStatsHandler(stats)
 }
 
 // ToProto converts this Scan into a protobuf message

--- a/region/client.go
+++ b/region/client.go
@@ -729,6 +729,9 @@ func (c *client) send(rpc hrpc.Call) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
+	if o, ok := rpc.(hrpc.RPCObserver); ok {
+		o.SetSendTime(time.Now())
+	}
 
 	b, err := marshalProto(rpc, id, request, cellblocksLen)
 	if err != nil {

--- a/rpc.go
+++ b/rpc.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/tsuna/gohbase/hrpc"
 	"github.com/tsuna/gohbase/internal/observability"
-	"github.com/tsuna/gohbase/pb"
 	"github.com/tsuna/gohbase/region"
 	"github.com/tsuna/gohbase/zk"
 	"go.opentelemetry.io/otel/attribute"
@@ -105,13 +104,18 @@ func (c *client) SendRPC(rpc hrpc.Call) (msg proto.Message, err error) {
 		if err != nil {
 			return nil, err
 		}
-		rpcStart := time.Now()
 		msg, err = c.sendRPCToRegionClient(ctx, rpc, rc)
+		if o, ok := rpc.(hrpc.RPCObserver); ok {
+			retryable := false
+			switch err.(type) {
+			case region.RetryableError, region.ServerError,
+				region.NotServingRegionError:
+				retryable = true
+			}
+			o.OnComplete(msg, err, retryable)
+		}
 		switch err.(type) {
 		case region.RetryableError:
-			if scan, ok := rpc.(*hrpc.Scan); ok {
-				c.scanRpcScanStats(scan, msg, err, true, rpcStart, time.Now())
-			}
 			sp.AddEvent("retrySleep")
 			backoff, err = sleepAndIncreaseBackoff(ctx, backoff)
 			if err != nil {
@@ -119,9 +123,6 @@ func (c *client) SendRPC(rpc hrpc.Call) (msg proto.Message, err error) {
 			}
 			continue // retry
 		case region.ServerError:
-			if scan, ok := rpc.(*hrpc.Scan); ok {
-				c.scanRpcScanStats(scan, msg, err, true, rpcStart, time.Now())
-			}
 			// Retry ServerError immediately, as we want failover fast to
 			// another server. But if HBase keep sending us ServerError, we
 			// should start to backoff. We don't want to overwhelm HBase.
@@ -135,61 +136,9 @@ func (c *client) SendRPC(rpc hrpc.Call) (msg proto.Message, err error) {
 			serverErrorCount++
 			continue // retry
 		case region.NotServingRegionError:
-			if scan, ok := rpc.(*hrpc.Scan); ok {
-				c.scanRpcScanStats(scan, msg, err, true, rpcStart, time.Now())
-			}
 			continue // retry
 		}
-		if scan, ok := rpc.(*hrpc.Scan); ok {
-			c.scanRpcScanStats(scan, msg, err, false, rpcStart, time.Now())
-		}
 		return msg, err
-	}
-}
-
-func (c *client) scanRpcScanStats(scan *hrpc.Scan, resp proto.Message, err error,
-	retry bool, start, end time.Time) {
-	if scan.ScanStatsHandler() != nil {
-		stats := &hrpc.ScanStats{}
-		// Update the ScanMetrics if they are being tracked. For ScanStats, these ScanMetrics
-		// are collected per call to SendRPC and therefore may not be reflective of the entire
-		// result of the Scan request if the results are split across multiple calls to
-		// Scanner.Next().
-		if scan.TrackScanMetrics() && resp != nil {
-			scanres, ok := resp.(*pb.ScanResponse)
-			if !ok {
-				c.logger.Debug("got non ScanResponse for ScanRequest, no ScanMetrics to add")
-			} else {
-				if scanres.ScanMetrics != nil {
-					stats.ScanMetrics = make(map[string]int64)
-					for _, m := range scanres.ScanMetrics.GetMetrics() {
-						stats.ScanMetrics[m.GetName()] = m.GetValue()
-					}
-				}
-			}
-		}
-
-		stats.Table = scan.Table()
-		stats.StartRow = scan.StartRow()
-		stats.EndRow = scan.StopRow()
-		if reg := scan.Region(); reg != nil {
-			stats.RegionID = reg.ID()
-			if cl := reg.Client(); cl != nil {
-				stats.RegionServer = cl.Addr()
-			}
-		}
-		stats.ScannerID = scan.ScannerId()
-		stats.ScanStatsID = scan.ScanStatsID()
-		stats.Start = start
-		stats.End = end
-		if err != nil {
-			stats.Error = true
-		}
-		stats.Retryable = retry
-		if scan.Response != nil {
-			stats.ResponseSize = scan.Response.ResponseSize
-		}
-		scan.ScanStatsHandler()(stats)
 	}
 }
 

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1975,14 +1975,12 @@ func TestSendRPCStatsHandler(t *testing.T) {
 	}
 }
 
-// TestScanRPCScanStatsScanMetricsNonScanResponse tests the helper that updates the ScanStats when
-// there's an unexpected response, either nil or a pb message that isn't the expected ScanResponse
-// type. This scenario could arise when sendBlocking returns an error, and along with it a nil rpc
-// result. In either case the handler can still update ScanStats, but when ScanMetrics is enabled,
-// it shouldn't be able to update it since there's no ScanResponse or ScanMetrics to do so.
-func TestScanRPCScanStatsScanMetricsNonScanResponse(t *testing.T) {
-	c := newMockClient(nil)
-
+// TestScanOnCompleteNilResponse tests Scan.OnComplete when there's an unexpected response,
+// either nil or a pb message that isn't the expected ScanResponse type. This scenario could
+// arise when sendBlocking returns an error, and along with it a nil rpc result. In either case
+// the handler can still update ScanStats, but when ScanMetrics is enabled, it shouldn't be able
+// to update it since there's no ScanResponse or ScanMetrics to do so.
+func TestScanOnCompleteNilResponse(t *testing.T) {
 	ss := &hrpc.ScanStats{}
 	h := func(stats *hrpc.ScanStats) {
 		ss = stats
@@ -2010,8 +2008,6 @@ func TestScanRPCScanStatsScanMetricsNonScanResponse(t *testing.T) {
 	ri.SetClient(rc)
 	scan.SetRegion(ri)
 	expectedScanStatsID := scan.ScanStatsID()
-	start := time.Unix(0, 11)
-	end := time.Unix(0, 77)
 
 	validateStats := func() {
 		if !bytes.Equal(ss.Table, expectedTable) ||
@@ -2020,8 +2016,7 @@ func TestScanRPCScanStatsScanMetricsNonScanResponse(t *testing.T) {
 			ss.RegionID != expectedRegionID ||
 			ss.RegionServer != addr ||
 			ss.ScannerID != noScannerID ||
-			ss.ScanStatsID != expectedScanStatsID ||
-			ss.Start != start || ss.End != end {
+			ss.ScanStatsID != expectedScanStatsID {
 			t.Fatalf("ScanStats not updated as expected, got: %v", ss)
 		}
 	}
@@ -2048,8 +2043,16 @@ func TestScanRPCScanStatsScanMetricsNonScanResponse(t *testing.T) {
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
 			ss = &hrpc.ScanStats{}
-			c.scanRpcScanStats(scan, nil, tc.err, false, start, end)
+			sendTime := time.Now()
+			scan.SetSendTime(sendTime)
+			scan.OnComplete(nil, tc.err, false)
 			validateStats()
+			if ss.Start != sendTime {
+				t.Fatalf("ScanStats Start %v != sendTime %v", ss.Start, sendTime)
+			}
+			if ss.End.Before(sendTime) {
+				t.Fatal("ScanStats End should be after Start")
+			}
 			if ss.ScanMetrics != nil {
 				t.Fatal("ScanStats set scanMetrics unexpectedly")
 			}


### PR DESCRIPTION
This fixes an issue where the duration of a scan request includes the time it is queued within gohbase waiting for the congestion control to release the scan.