### PR TITLE
region: Add native histogram config for scan_queue_latency_seconds

### DIFF
--- a/region/prometheus.go
+++ b/region/prometheus.go
@@ -6,6 +6,8 @@
 package region
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -75,7 +77,20 @@ var (
 			Namespace: "gohbase",
 			Name:      "scan_queue_latency_seconds",
 			Help:      "Time spent waiting to execute a scan request",
-			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 17),
+
+			// TODO: Buckets can be removed when NativeHistogram is adopted.
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 17),
+
+			// Recommended default NativeHistogram settings:
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+
+			// 2^-20 ≈ 954ns ≈ 1us — captures "token was ready" fast
+			// path and places those results in the zero bucket. This
+			// removes histogram fidelity at sub ~1us and saves it for
+			// the higher end of the scale.
+			NativeHistogramZeroThreshold: 0x1p-20,
 		},
 		[]string{"regionserver"},
 	)


### PR DESCRIPTION
This metric results in a lot of series on HBase clusters with lots of region servers. Use native histograms for more efficient and accurate metric tracking.