### PR TITLE
Add QueueTime to ScanStats

### DIFF
--- a/hrpc/call.go
+++ b/hrpc/call.go
@@ -67,6 +67,13 @@ type Call interface {
 // RPCObserver is optionally implemented by RPCs that track
 // per-attempt timing and completion statistics.
 type RPCObserver interface {
+	// SetQueueTime is called by the region client before requesting a
+	// congestion control token (registerRPC). The difference between
+	// this time and the SendTime is the duration spent queued by
+	// congestion control. If it is not called then congestion control
+	// is not enabled.
+	SetQueueTime(time.Time)
+
 	// SetSendTime is called by the region client right after the RPC clears
 	// congestion control (registerRPC), before marshaling and writing to the wire.
 	SetSendTime(time.Time)

--- a/hrpc/scan.go
+++ b/hrpc/scan.go
@@ -156,6 +156,7 @@ type Scan struct {
 
 	scanStatsHandler ScanStatsHandler
 	scanStatsID      int64
+	queueTime        time.Time
 	sendTime         time.Time
 
 	// Response contains the scan's response after the RPC is
@@ -174,6 +175,7 @@ type ScanStats struct {
 	// ScanMetrics are only collected if the client requests to track the scan metrics, when
 	// TrackScanMetrics() is enabled.
 	ScanMetrics  map[string]int64
+	QueueTime    time.Time
 	Start        time.Time
 	End          time.Time
 	ResponseSize int
@@ -324,6 +326,12 @@ func (s *Scan) ScanStatsID() int64 {
 	return s.scanStatsID
 }
 
+// SetQueueTime implements RPCObserver. It is called by the region client
+// before requesting a congestion control token.
+func (s *Scan) SetQueueTime(t time.Time) {
+	s.queueTime = t
+}
+
 // SetSendTime implements RPCObserver. It is called by the region client
 // right after congestion control releases the RPC.
 func (s *Scan) SetSendTime(t time.Time) {
@@ -343,10 +351,15 @@ func (s *Scan) OnComplete(msg proto.Message, err error, retryable bool) {
 		EndRow:      s.stopRow,
 		ScannerID:   s.scannerID,
 		ScanStatsID: s.scanStatsID,
+		QueueTime:   s.queueTime,
 		Start:       s.sendTime,
 		End:         time.Now(),
 		Error:       err != nil,
 		Retryable:   retryable,
+	}
+
+	if stats.QueueTime.IsZero() {
+		stats.QueueTime = stats.Start
 	}
 
 	if s.trackScanMetrics && msg != nil {

--- a/region/client.go
+++ b/region/client.go
@@ -340,6 +340,10 @@ func (c *client) registerRPC(rpc hrpc.Call) (uint32, error) {
 	if _, isScan := rpc.(*hrpc.Scan); isScan && c.scanTokenBucket != nil &&
 		hrpc.GetPriority(rpc) == 0 {
 		t := time.Now()
+		if o, ok := rpc.(hrpc.RPCObserver); ok {
+			o.SetQueueTime(t)
+		}
+
 		if err := c.scanTokenBucket.Take(rpc.Context()); err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
QueueTime is the time a Scan starts requesting a token from congestion control. Start.Sub(QueueTime) is the duration spent queued.