### PR TITLE
Add Tests for CheckAndMutate ifNotExists conditions

### DIFF
--- a/hrpc/checkandmutate_test.go
+++ b/hrpc/checkandmutate_test.go
@@ -15,6 +15,84 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+func assertColumnCondition(
+	t *testing.T,
+	cond *pb.Condition,
+	key []byte,
+	cf, qualifier string,
+	compareType pb.CompareType,
+) {
+	t.Helper()
+
+	if cond == nil {
+		t.Fatal("expected Condition to be set")
+	}
+	if !bytes.Equal(cond.Row, key) {
+		t.Errorf("expected row %q, got %q", key, cond.Row)
+	}
+	if !bytes.Equal(cond.Family, []byte(cf)) {
+		t.Errorf("expected family %q, got %q", cf, cond.Family)
+	}
+	if !bytes.Equal(cond.Qualifier, []byte(qualifier)) {
+		t.Errorf("expected qualifier %q, got %q", qualifier, cond.Qualifier)
+	}
+	if cond.GetCompareType() != compareType {
+		t.Errorf("expected compare type %v, got %v", compareType, cond.GetCompareType())
+	}
+	if cond.Comparator == nil {
+		t.Fatal("expected Comparator to be set")
+	}
+	if cond.Filter != nil {
+		t.Error("expected Filter to be nil for column condition")
+	}
+}
+
+func TestCheckAndMutateIfNotExists(t *testing.T) {
+	ctx := context.Background()
+	table := []byte("table")
+	key := []byte("key")
+	cf := "cf"
+	checkQualifier := "new_col"
+	newData := []byte("newData")
+
+	put, err := NewPut(ctx, table, key, map[string]map[string][]byte{
+		cf: {checkQualifier: newData},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cam, err := NewCheckAndMutate(put, cf, checkQualifier, pb.CompareType_EQUAL,
+		filter.NewBinaryComparator(filter.NewByteArrayComparable(nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cam.SkipBatch() {
+		t.Error("expected SkipBatch to be true")
+	}
+
+	cam.SetRegion(mockRegionInfo("region"))
+	req := cam.ToProto().(*pb.MutateRequest)
+
+	assertColumnCondition(t, req.Condition, key, cf, checkQualifier, pb.CompareType_EQUAL)
+
+	mutation := req.Mutation
+	if mutation == nil {
+		t.Fatal("expected Mutation to be set")
+	}
+	if len(mutation.ColumnValue) != 1 || len(mutation.ColumnValue[0].QualifierValue) != 1 {
+		t.Fatalf("expected single column value, got %v", mutation.ColumnValue)
+	}
+	qv := mutation.ColumnValue[0].QualifierValue[0]
+	if got := qv.Qualifier; !bytes.Equal(got, []byte(checkQualifier)) {
+		t.Errorf("expected mutation qualifier %q, got %q", checkQualifier, got)
+	}
+	if got := qv.Value; !bytes.Equal(got, newData) {
+		t.Errorf("expected mutation value %q, got %q", newData, got)
+	}
+}
+
 func TestCheckAndMutateWithFilter(t *testing.T) {
 	ctx := context.Background()
 	table := []byte("table")

--- a/integration_test.go
+++ b/integration_test.go
@@ -1705,6 +1705,103 @@ func TestCheckAndMutateDelete(t *testing.T) {
 	}
 }
 
+func TestCheckAndMutateIfNotExistsMultipleColumns(t *testing.T) {
+	c := gohbase.NewClient(*host)
+	defer c.Close()
+
+	cf := "cf"
+	mutationQual := "target"
+	newData := []byte("newData")
+	checkColumns := []string{"key1", "key2"}
+
+	checkFilters := make([]filter.Filter, len(checkColumns))
+	for i, col := range checkColumns {
+		checkFilters[i] = columnNotExistsFilter(cf, col)
+	}
+	condFilter := filter.NewList(filter.MustPassAll, checkFilters...)
+
+	tests := []struct {
+		name          string
+		setupData     map[string][]byte
+		shouldProcess bool
+		storedVal     []byte
+	}{
+		{
+			name:          "none of the keys exist yet, will store",
+			setupData:     map[string][]byte{"other": []byte("someNewValue")},
+			shouldProcess: true,
+			storedVal:     newData,
+		},
+		{
+			name:          "one of the checked keys already exists, will not store",
+			setupData:     map[string][]byte{"key1": []byte("aValueToSomeExistingKey")},
+			shouldProcess: false,
+		},
+		{
+			name: "both of the checked keys already exists, will not store",
+			setupData: map[string][]byte{
+				"key1": []byte("aValueToSomeExistingKey"),
+				"key2": []byte("bValueToSomeExistingKey"),
+			},
+			shouldProcess: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := fmt.Sprintf("row_cam_ifnotexists_multi_%d", time.Now().UnixNano())
+
+			putReq, err := hrpc.NewPutStr(context.Background(), table, key,
+				map[string]map[string][]byte{cf: tt.setupData})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err = c.Put(putReq); err != nil {
+				t.Fatal(err)
+			}
+
+			mutationReq, err := hrpc.NewPutStr(context.Background(), table, key,
+				map[string]map[string][]byte{cf: {mutationQual: newData}})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cam, err := hrpc.NewCheckAndMutateWithFilter(mutationReq, condFilter)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result, err := c.CheckAndMutate(cam)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result != tt.shouldProcess {
+				t.Errorf("got processed=%v, want %v", result, tt.shouldProcess)
+			}
+
+			getReq, err := hrpc.NewGetStr(context.Background(), table, key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			getRes, err := c.Get(getReq)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var storedVal []byte
+			for _, cell := range getRes.Cells {
+				if string(cell.Qualifier) == mutationQual {
+					storedVal = cell.Value
+					break
+				}
+			}
+			if !bytes.Equal(storedVal, tt.storedVal) {
+				t.Errorf("got target value=%q, want %q", storedVal, tt.storedVal)
+			}
+		})
+	}
+}
+
 func TestCheckAndMutateWithFilter(t *testing.T) {
 	c := gohbase.NewClient(*host)
 	defer c.Close()
@@ -1714,6 +1811,8 @@ func TestCheckAndMutateWithFilter(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		rowKey         string
+		skipSetup      bool
 		setupData      map[string][]byte
 		filter         filter.Filter
 		mutationVal    []byte
@@ -1822,20 +1921,73 @@ func TestCheckAndMutateWithFilter(t *testing.T) {
 			wantProcessed:  true,
 			wantFinalValue: []byte("one_matched"),
 		},
+		{
+			name:      "at least one checked key exists should store",
+			rowKey:    "row_cam_filter_partial",
+			setupData: map[string][]byte{"key1": []byte("v1")},
+			filter: filter.NewList(filter.MustPassAll,
+				filter.NewSingleColumnValueFilter(
+					[]byte(cf), []byte("key1"),
+					filter.Equal,
+					filter.NewBinaryComparator(
+						filter.NewByteArrayComparable([]byte("v1"))),
+					false, false),
+				filter.NewSingleColumnValueFilter(
+					[]byte(cf), []byte("key2"),
+					filter.Equal,
+					filter.NewBinaryComparator(
+						filter.NewByteArrayComparable([]byte("v2"))),
+					false, false),
+			),
+			mutationVal:    []byte("surprise_stored"),
+			wantProcessed:  true,
+			wantFinalValue: []byte("surprise_stored"),
+		},
+		{
+			// A row with no cells fails the filter check regardless of filterIfMissing.
+			// This is a quirk of HBase. No row to scan, so filter never evaluates.
+			name:      "none of the checked keys exist should not store",
+			rowKey:    "row_cam_filter_empty",
+			skipSetup: true,
+			filter: filter.NewList(filter.MustPassAll,
+				filter.NewSingleColumnValueFilter(
+					[]byte(cf), []byte("key1"),
+					filter.Equal,
+					filter.NewBinaryComparator(
+						filter.NewByteArrayComparable([]byte("v1"))),
+					false, false),
+				filter.NewSingleColumnValueFilter(
+					[]byte(cf), []byte("key2"),
+					filter.Equal,
+					filter.NewBinaryComparator(
+						filter.NewByteArrayComparable([]byte("v2"))),
+					false, false),
+			),
+			mutationVal:    []byte("never_stored"),
+			wantProcessed:  false,
+			wantFinalValue: nil,
+		},
 	}
 
 	// Note that these cases were meant to be run sequentially, not in parallel
 	for _, tt := range tests {
-		putReq, err := hrpc.NewPutStr(context.Background(), table, key,
-			map[string]map[string][]byte{cf: tt.setupData})
-		if err != nil {
-			t.Fatalf("%s: %v", tt.name, err)
-		}
-		if _, err = c.Put(putReq); err != nil {
-			t.Fatalf("%s: %v", tt.name, err)
+		rowKey := key
+		if tt.rowKey != "" {
+			rowKey = tt.rowKey
 		}
 
-		mutationReq, err := hrpc.NewPutStr(context.Background(), table, key,
+		if !tt.skipSetup {
+			putReq, err := hrpc.NewPutStr(context.Background(), table, rowKey,
+				map[string]map[string][]byte{cf: tt.setupData})
+			if err != nil {
+				t.Fatalf("%s: %v", tt.name, err)
+			}
+			if _, err = c.Put(putReq); err != nil {
+				t.Fatalf("%s: %v", tt.name, err)
+			}
+		}
+
+		mutationReq, err := hrpc.NewPutStr(context.Background(), table, rowKey,
 			map[string]map[string][]byte{cf: {"key1": tt.mutationVal}})
 		if err != nil {
 			t.Fatalf("%s: %v", tt.name, err)
@@ -1856,7 +2008,7 @@ func TestCheckAndMutateWithFilter(t *testing.T) {
 				tt.name, result, tt.wantProcessed)
 		}
 
-		getReq, err := hrpc.NewGetStr(context.Background(), table, key)
+		getReq, err := hrpc.NewGetStr(context.Background(), table, rowKey)
 		if err != nil {
 			t.Fatalf("%s: %v", tt.name, err)
 		}
@@ -2016,6 +2168,15 @@ func performNPuts(keyPrefix string, num_ops int) error {
 func insertKeyValue(c gohbase.Client, key, columnFamily string, value []byte,
 	options ...func(hrpc.Call) error) error {
 	return insertKeyValueAtCol(c, key, "a", columnFamily, value, options...)
+}
+
+// columnNotExistsFilter returns a filter that passes when the given column is absent.
+func columnNotExistsFilter(columnFamily, qualifier string) filter.Filter {
+	return filter.NewSingleColumnValueFilter(
+		[]byte(columnFamily), []byte(qualifier),
+		filter.Equal,
+		filter.NewBinaryComparator(filter.NewByteArrayComparable(nil)),
+		false, false)
 }
 
 // insertKeyValueAtCol inserts a value into the table under column col at key.

--- a/integration_test.go
+++ b/integration_test.go
@@ -1812,7 +1812,6 @@ func TestCheckAndMutateWithFilter(t *testing.T) {
 	tests := []struct {
 		name           string
 		rowKey         string
-		skipSetup      bool
 		setupData      map[string][]byte
 		filter         filter.Filter
 		mutationVal    []byte
@@ -1939,16 +1938,15 @@ func TestCheckAndMutateWithFilter(t *testing.T) {
 						filter.NewByteArrayComparable([]byte("v2"))),
 					false, false),
 			),
-			mutationVal:    []byte("surprise_stored"),
+			mutationVal:    []byte("stored_value"),
 			wantProcessed:  true,
-			wantFinalValue: []byte("surprise_stored"),
+			wantFinalValue: []byte("stored_value"),
 		},
 		{
 			// A row with no cells fails the filter check regardless of filterIfMissing.
 			// This is a quirk of HBase. No row to scan, so filter never evaluates.
-			name:      "none of the checked keys exist should not store",
-			rowKey:    "row_cam_filter_empty",
-			skipSetup: true,
+			name:   "none of the checked keys exist should not store",
+			rowKey: "row_cam_filter_empty",
 			filter: filter.NewList(filter.MustPassAll,
 				filter.NewSingleColumnValueFilter(
 					[]byte(cf), []byte("key1"),
@@ -1971,64 +1969,66 @@ func TestCheckAndMutateWithFilter(t *testing.T) {
 
 	// Note that these cases were meant to be run sequentially, not in parallel
 	for _, tt := range tests {
-		rowKey := key
-		if tt.rowKey != "" {
-			rowKey = tt.rowKey
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			rowKey := key
+			if tt.rowKey != "" {
+				rowKey = tt.rowKey
+			}
 
-		if !tt.skipSetup {
-			putReq, err := hrpc.NewPutStr(context.Background(), table, rowKey,
-				map[string]map[string][]byte{cf: tt.setupData})
+			if len(tt.setupData) != 0 {
+				putReq, err := hrpc.NewPutStr(context.Background(), table, rowKey,
+					map[string]map[string][]byte{cf: tt.setupData})
+				if err != nil {
+					t.Fatalf("%s: %v", tt.name, err)
+				}
+				if _, err = c.Put(putReq); err != nil {
+					t.Fatalf("%s: %v", tt.name, err)
+				}
+			}
+
+			mutationReq, err := hrpc.NewPutStr(context.Background(), table, rowKey,
+				map[string]map[string][]byte{cf: {"key1": tt.mutationVal}})
 			if err != nil {
 				t.Fatalf("%s: %v", tt.name, err)
 			}
-			if _, err = c.Put(putReq); err != nil {
+
+			cam, err := hrpc.NewCheckAndMutateWithFilter(mutationReq, tt.filter)
+			if err != nil {
 				t.Fatalf("%s: %v", tt.name, err)
 			}
-		}
 
-		mutationReq, err := hrpc.NewPutStr(context.Background(), table, rowKey,
-			map[string]map[string][]byte{cf: {"key1": tt.mutationVal}})
-		if err != nil {
-			t.Fatalf("%s: %v", tt.name, err)
-		}
-
-		cam, err := hrpc.NewCheckAndMutateWithFilter(mutationReq, tt.filter)
-		if err != nil {
-			t.Fatalf("%s: %v", tt.name, err)
-		}
-
-		result, err := c.CheckAndMutate(cam)
-		if err != nil {
-			t.Fatalf("%s: %v", tt.name, err)
-		}
-
-		if result != tt.wantProcessed {
-			t.Errorf("%s: got processed=%v, want %v",
-				tt.name, result, tt.wantProcessed)
-		}
-
-		getReq, err := hrpc.NewGetStr(context.Background(), table, rowKey)
-		if err != nil {
-			t.Fatalf("%s: %v", tt.name, err)
-		}
-		getRes, err := c.Get(getReq)
-		if err != nil {
-			t.Fatalf("%s: %v", tt.name, err)
-		}
-
-		var actualValue []byte
-		for _, cell := range getRes.Cells {
-			if string(cell.Qualifier) == "key1" {
-				actualValue = cell.Value
-				break
+			result, err := c.CheckAndMutate(cam)
+			if err != nil {
+				t.Fatalf("%s: %v", tt.name, err)
 			}
-		}
 
-		if !bytes.Equal(actualValue, tt.wantFinalValue) {
-			t.Errorf("%s: got value=%q, want %q",
-				tt.name, actualValue, tt.wantFinalValue)
-		}
+			if result != tt.wantProcessed {
+				t.Errorf("%s: got processed=%v, want %v",
+					tt.name, result, tt.wantProcessed)
+			}
+
+			getReq, err := hrpc.NewGetStr(context.Background(), table, rowKey)
+			if err != nil {
+				t.Fatalf("%s: %v", tt.name, err)
+			}
+			getRes, err := c.Get(getReq)
+			if err != nil {
+				t.Fatalf("%s: %v", tt.name, err)
+			}
+
+			var actualValue []byte
+			for _, cell := range getRes.Cells {
+				if string(cell.Qualifier) == "key1" {
+					actualValue = cell.Value
+					break
+				}
+			}
+
+			if !bytes.Equal(actualValue, tt.wantFinalValue) {
+				t.Errorf("%s: got value=%q, want %q",
+					tt.name, actualValue, tt.wantFinalValue)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Adds tests for multi-column CheckAndMutate calls with nil comparators. Whereas CheckAndPut with a `nil` comparator value is treated as "write if not exists", CheckAndMutate does not behave the same way. Regardless of filterIfMissing, if none of the keys exist, then the values are not written. If at least one of the keys exist, then the values will be written (provided filterIfMissing=false). This is an HBase implementation. Instead, one has to create a ifNotExists filter in order for these changes to be applied, which represent the other half of the tests introduced in this commit.